### PR TITLE
Adds Makefile / Dockerfile / README basic setups

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+# PORT needs to be exported for NextJS
+export PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
-.env*.local
+# .env files
+.env*
+!.env.sample
 
 # vercel
 .vercel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# ===================================
+# =========== BUILD IMAGE ===========
+# ===================================
+FROM node:22-alpine AS BUILD_IMAGE
+
+# Set the Current Working Directory inside the container
+WORKDIR /app
+
+# Copy package.json files
+COPY package.json package-lock.json ./
+
+# Download all dependencies. Dependencies will be cached
+# if the package.json files are not changed
+RUN npm i
+
+# Copy the source from the current directory to
+# the Working Directory inside the container
+COPY . .
+
+# Compile the website (production build)
+RUN npm run build
+
+# remove development dependencies
+RUN npm prune --production
+
+# ===================================
+# ========== RUNTIME IMAGE ==========
+# ===================================
+FROM node:22-alpine
+
+# Set the Current Working Directory inside the container
+WORKDIR /app
+
+# Adds Bash for env variable access (alpine does not ship w/ Bash)
+RUN apk update && apk add bash
+
+COPY --from=BUILD_IMAGE /app/.next ./.next
+COPY --from=BUILD_IMAGE /app/public ./public
+COPY --from=BUILD_IMAGE /app/node_modules ./node_modules
+COPY --from=BUILD_IMAGE /app/package.json ./package.json
+
+# Run it
+CMD npm run start

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: dev
+dev: node_modules/.installed .env.local
+	source .env.local && npm run dev
+
+node_modules/.installed: package.json
+	npm i && touch node_modules/.installed
+
+.env.local:
+	cp .env.sample .env.local
+
+# ====================================
+# ======= Docker Configuration =======
+# ====================================
+
+.PHONY: docker
+docker: .env.local docker-build
+	source .env.local && docker compose up
+
+.PHONY: docker-build
+docker-build:
+	docker compose build

--- a/README.md
+++ b/README.md
@@ -1,40 +1,33 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+<h1>
+  <p align="center">
+    <img src="https://user-images.githubusercontent.com/1299/199110421-9ff5fc30-a244-441e-9882-26070662adf9.png" alt="Logo" width="100">
+    <br>Ghostty Website
+  </p>
+</h1>
+<p align="center">
+  This repository contains the entire source for <a href="https://ghostty.org">ghostty.org</a>.
+</p>
 
-## Getting Started
+## Local Development
 
-First, run the development server:
+### via Node (recommended)
+
+To spin up a local server, you can simply run `make`.
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+make
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) with your browser to view the website.
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+### via Docker
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
+If you don't have node configured, you can also build the website locally with Docker.
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+This approach will compile a [production build](https://nextjs.org/docs/pages/building-your-application/deploying#production-builds), which is  less ideal for local development.
 
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+```bash
+make docker
+```
 
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+Open [http://localhost:3000](http://localhost:3000) with your browser to view the website.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  website:
+    container_name: ghostty-website
+    build: .
+    image: ghostty-org/website
+    environment:
+      - PORT
+    ports:
+      - "${PORT}:${PORT}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,12 @@
         "react-dom": "^18"
       },
       "devDependencies": {
-        "@types/node": "^20",
-        "@types/react": "^18",
+        "@types/node": "20.14.13",
+        "@types/react": "18.3.3",
         "@types/react-dom": "^18",
         "eslint": "^8",
         "eslint-config-next": "14.2.5",
-        "typescript": "^5"
+        "typescript": "5.5.4"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -9,16 +9,16 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "14.2.5",
     "react": "^18",
-    "react-dom": "^18",
-    "next": "14.2.5"
+    "react-dom": "^18"
   },
   "devDependencies": {
-    "typescript": "^5",
-    "@types/node": "^20",
-    "@types/react": "^18",
+    "@types/node": "20.14.13",
+    "@types/react": "18.3.3",
     "@types/react-dom": "^18",
     "eslint": "^8",
-    "eslint-config-next": "14.2.5"
+    "eslint-config-next": "14.2.5",
+    "typescript": "5.5.4"
   }
 }


### PR DESCRIPTION
- Introduces a base `make` command here which installs deps / sets env etc
- Introduces a `make docker` command which runs the website in docker, for folks who don't have node setup on their machines.
- Adds a basic README, stealing some format from [ghostty-org/ghostty](https://github.com/ghostty-org/ghostty)