### PR TITLE
Fix a bug with the terminal scrolling the entire page

### DIFF
--- a/src/components/terminal/index.tsx
+++ b/src/components/terminal/index.tsx
@@ -34,12 +34,12 @@ export default function Terminal({
     }
   };
 
-  const lastLineRef = useRef<HTMLInputElement>(null);
+  const codeRef = useRef<HTMLElement>(null);
   useEffect(() => {
     if (autoScroll) {
-      lastLineRef.current?.scrollIntoView({
+      codeRef.current?.scrollTo({
+        top: codeRef.current.scrollHeight,
         behavior: "instant",
-        block: "nearest",
       });
     }
   }, [lines?.length, autoScroll]);
@@ -66,7 +66,7 @@ export default function Terminal({
         </ul>
         <P className={s.title}>{title}</P>
       </div>
-      <Code className={s.content} onScroll={handleScroll}>
+      <Code ref={codeRef} className={s.content} onScroll={handleScroll}>
         {lines?.map((line, i) => {
           return (
             <div key={i + line}>
@@ -75,7 +75,6 @@ export default function Terminal({
             </div>
           );
         })}
-        <div ref={lastLineRef} />
       </Code>
     </div>
   );

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import localFont from "next/font/local";
-import { UIEventHandler } from "react";
+import { forwardRef, UIEventHandler } from "react";
 import s from "./Text.module.css";
 
 // https://github.com/orioncactus/pretendard
@@ -10,6 +10,7 @@ export const pretendardVariable = localFont({
   variable: "--pretendard-variable",
 });
 
+// https://www.jetbrains.com/lp/mono/
 export const jetbrainsMono = localFont({
   src: "./font/jetbrains-mono-regular.woff2",
   display: "auto",
@@ -27,18 +28,22 @@ interface TextProps {
   onScroll?: UIEventHandler<HTMLElement>;
 }
 
-export default function Text({
-  as: Tag,
-  children,
-  className,
-  id,
-  font = "body",
-  weight = "light",
-  onScroll,
-}: TextProps) {
+const Text = forwardRef<HTMLElement, TextProps>(function Text(
+  {
+    as: Tag,
+    children,
+    className,
+    id,
+    font = "body",
+    weight = "light",
+    onScroll,
+  }: TextProps,
+  ref: React.Ref<HTMLElement>
+) {
   return (
     <Tag
       id={id}
+      ref={ref as any}
       onScroll={onScroll}
       className={classNames(s.text, className, {
         [pretendardVariable.className]: font === "display" || font === "body",
@@ -50,107 +55,63 @@ export default function Text({
       {children}
     </Tag>
   );
-}
+});
+export default Text;
 
 type SpecificTagTextProps = Omit<TextProps, "as">;
 
-export function Code(props: SpecificTagTextProps) {
-  return Text({
-    font: "code",
-    weight: "regular",
-    as: "code",
-    ...props,
-  });
-}
+export const Code = forwardRef<HTMLElement, SpecificTagTextProps>(function Code(
+  props: SpecificTagTextProps,
+  ref: React.Ref<HTMLElement>
+) {
+  return <Text ref={ref} font="code" weight="regular" as="code" {...props} />;
+});
 
 export function LI(props: SpecificTagTextProps) {
-  return Text({
-    font: "body",
-    weight: "light",
-    as: "li",
-    ...props,
-  });
+  return <Text as="li" font="body" weight="light" {...props} />;
 }
 
 export function BodyParagraph(props: SpecificTagTextProps) {
   const { className, ...otherProps } = props;
-  return Text({
-    font: "body",
-    weight: "regular",
-    as: "p",
-    className: classNames(s.body, className),
-    ...otherProps,
-  });
+  return (
+    <Text
+      font="body"
+      weight="regular"
+      as="p"
+      className={classNames(s.body, className)}
+      {...otherProps}
+    />
+  );
 }
 
 export function P(props: SpecificTagTextProps) {
-  return Text({
-    font: "body",
-    weight: "light",
-    as: "p",
-    ...props,
-  });
+  return <Text as="p" font="body" weight="light" {...props} />;
 }
 
 export function Span(props: SpecificTagTextProps) {
-  return Text({
-    font: "body",
-    weight: "light",
-    as: "span",
-    ...props,
-  });
+  return <Text as="span" font="body" weight="light" {...props} />;
 }
 
 export function H1(props: SpecificTagTextProps) {
-  return Text({
-    font: "display",
-    weight: "medium",
-    as: "h1",
-    ...props,
-  });
+  return <Text as="h1" font="display" weight="medium" {...props} />;
 }
 
 export function H2(props: SpecificTagTextProps) {
-  return Text({
-    font: "display",
-    weight: "medium",
-    as: "h2",
-    ...props,
-  });
+  return <Text as="h2" font="display" weight="medium" {...props} />;
 }
 
 export function H3(props: SpecificTagTextProps) {
-  return Text({
-    font: "display",
-    weight: "medium",
-    as: "h3",
-    ...props,
-  });
+  return <Text as="h3" font="display" weight="medium" {...props} />;
 }
 
 export function H4(props: SpecificTagTextProps) {
-  return Text({
-    font: "display",
-    weight: "medium",
-    as: "h4",
-    ...props,
-  });
+  return <Text as="h4" font="display" weight="medium" {...props} />;
 }
 
 export function H5(props: SpecificTagTextProps) {
-  return Text({
-    font: "display",
-    weight: "medium",
-    as: "h5",
-    ...props,
-  });
+  return <Text as="h5" font="display" weight="medium" {...props} />;
 }
 
 export function H6(props: SpecificTagTextProps) {
-  return Text({
-    font: "display",
-    weight: "medium",
-    as: "h6",
-    ...props,
-  });
+  return <Text as="h6" font="display" weight="medium" {...props} />;
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,12 +22,9 @@ export default function Home() {
       }}
     >
       <main className={s.homePage}>
-        {/*
-        TODO: Temporarily disabling this as it is scrolling the entire page with scrollIntoView
         <SectionWrapper>
           <AnimatedTerminalPOC className={s.terminal} />
         </SectionWrapper>
-        */}
 
         <InfoCardsSection
           title="Ghostty is a cross-platform, GPU-accelerated terminal emulator designed to eerily-enhance and expand CLI capabilities."


### PR DESCRIPTION
`scrollIntoView` was problematic in the scenario where the terminal was out of view, as it would scroll the entire page to the terminal.

Adjusting to use `scrollTo`. This PR is slightly bigger as I had to introduce some forwardRefs to a few text components to get a ref on the code element itself.