### PR TITLE
Scroll to top when navigating between pages

### DIFF
--- a/src/layouts/root-layout/RootLayout.module.css
+++ b/src/layouts/root-layout/RootLayout.module.css
@@ -1,7 +1,4 @@
 .rootLayout {
-  overflow: auto;
-  height: 100vh;
-
   font-family: var(--pretendard-variable);
 
   & a {

--- a/src/pages/docs/[...path]/DocsPage.module.css
+++ b/src/pages/docs/[...path]/DocsPage.module.css
@@ -11,14 +11,14 @@
       display: none;
     }
     border-right: 1px solid var(--gray-2);
-    & .sidebarContentWrapper {
-      position: sticky;
-      top: var(--header-height);
-      min-height: calc(100vh - var(--header-height) - var(--footer-height));
-      max-height: calc(100vh - var(--header-height));
-      padding: 24px 14px;
-      overflow: scroll;
+    position: sticky;
+    top: var(--header-height);
+    overflow: scroll;
+    max-height: calc(100vh - var(--header-height));
+    min-height: calc(100vh - var(--header-height) - var(--footer-height));
 
+    & .sidebarContentWrapper {
+      padding: 24px 14px;
       & > .sidebarNavTree {
         padding: 2px; /* guarantee space for focus border */
         height: 100%;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -11,7 +11,6 @@
 html,
 body {
   max-width: 100vw;
-  overflow-x: hidden;
   background: var(--gray-0);
 }
 


### PR DESCRIPTION
Fixes #37

This re-introduces #30 as a bug though, but this one is better to deal with.

I actually think #30 might be close to impossible to solve with this layout (or at least, beyond me, for now!). I need to specify a max-height on the sticky container so the Sidenav can independently be scrolled from the content.  This max-height differs depending on if the footer is in view or not.