### PR TITLE
style: set proper borders & color for nav break nodes

### DIFF
--- a/src/components/nav-tree/NavTree.module.css
+++ b/src/components/nav-tree/NavTree.module.css
@@ -38,7 +38,7 @@ ul.nodesList {
         }
       }
       & svg {
-        transition: transform .2s;
+        transition: transform 0.2s;
       }
       &.isOpen {
         & svg {
@@ -51,10 +51,8 @@ ul.nodesList {
     }
 
     & .breakNode {
-      border-top: none;
-      border-left: none;
-      border-right: none;
-      color: var(--gray-2);
+      border: none;
+      border-bottom: 1px solid var(--gray-2);
       margin: 20px 0;
     }
 


### PR DESCRIPTION
Loving this website's look & feel! One thing I noticed right away was the huge contrast the navbar's separator node had in comparison to the rest of the website's borders & `hr`s:

<img width="354" alt="Screenshot 2024-12-19 at 4 33 27 PM" src="https://github.com/user-attachments/assets/13899c20-ccdc-4b46-bb18-f404d720f0bd" />

For an `hr`, the `border-color` property does the trick. 

<img width="354" alt="Screenshot 2024-12-19 at 4 36 24 PM" src="https://github.com/user-attachments/assets/22ce0da5-12bb-46ba-a5b1-a49669923cb9" />

Simplified the border declaration as well. (:

NOTE: I've seen some screenshots running around the Discord where, strangely enough, I don't see this issue. I've tested on both Arc and Chrome, but please do let me know if this isn't how it looks in other people's machines.