### PR TITLE
feat(ui): add bottom padding for homepage

### DIFF
--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -1,7 +1,8 @@
 .homePage {
+  padding: 32px 0;
+
   & .terminalWrapper {
-    padding-top: 32px;
-    padding-bottom: 20px;
+    margin-bottom: 20px;
     display: grid;
     place-content: center;
     overflow: hidden;


### PR DESCRIPTION
This PR applies the top and bottom padding to the `.homePage` element instead of the `.terminalWrapper`, ensuring a minimal bottom padding of 32px. Also, as an opportunistic improvement, changing `.terminalWrapper`'s `padding-bottom` to `margin-bottom` (of the same value, of course) as it's the surrounding space.