### PR TITLE
feat(a11y): disable animation for reduced motion

### DIFF
--- a/src/components/animated-terminal/index.tsx
+++ b/src/components/animated-terminal/index.tsx
@@ -20,6 +20,13 @@ export default function AnimatedTerminal({
 }: AnimatedTerminalPocProps) {
   const [currentFrame, setCurrentFrame] = useState(0);
   useEffect(() => {
+    const reducedMotion = window.matchMedia(`(prefers-reduced-motion: reduce)`).matches === true;
+
+    if (reducedMotion) {
+      setCurrentFrame(20);
+      return;
+    }
+
     const interval = setInterval(() => {
       setCurrentFrame((currentFrame) => {
         return (currentFrame + 1) % frames.length;
@@ -27,6 +34,7 @@ export default function AnimatedTerminal({
     }, frameLengthMs);
     return () => clearInterval(interval);
   }, []);
+
   return (
     <Terminal
       className={className}


### PR DESCRIPTION
While super cool, the animation should respect a user's setting to disable non-essential animations. This PR detects the `prefers-reduced-motion` media query and only renders a static frame (20th, but please let me know if you prefer another) in such a case.

![image](https://github.com/user-attachments/assets/27f760a9-8d86-4b56-b24d-bd342f4ad438)

I'm not a React expert, so feedback is most welcome!