### PR TITLE
feat(ui): more accurate terminal button style

### DIFF
--- a/src/components/terminal/Terminal.module.css
+++ b/src/components/terminal/Terminal.module.css
@@ -1,7 +1,12 @@
 .terminal {
   --code-margin-top: 12px;
-  --control-size: 10px;
-  --padding: 10px;
+  --control-size: 12px;
+  --padding: 7px;
+
+  /* Mac's traffic light button colors */
+  --color-sunset-orange: #ff605c;
+  --color-pastel-orange: #ffbd44;
+  --color-malachite: #00ca4e;
 
   &.fontXTiny {
     --title-font-size: 12px;
@@ -53,7 +58,7 @@
     & .windowControls {
       list-style: none;
       display: flex;
-      gap: 6px;
+      gap: 8px;
 
       & li {
         width: var(--control-size);
@@ -66,6 +71,7 @@
       position: absolute;
       left: 50%; transform: translateX(-50%);
       font-size: var(--title-font-size);
+      top: 1px;
     }
   }
 
@@ -83,6 +89,22 @@
       white-space: pre-wrap;
       & :global(.b) {
         color: var(--brand-color);
+      }
+    }
+  }
+
+  &:focus {
+    & .header {
+      & .windowControls {
+        & li:first-child {
+          background: var(--color-sunset-orange);
+        }
+        & li:nth-child(2) {
+          background: var(--color-pastel-orange);
+        }
+        & li:last-child {
+          background: var(--color-malachite);
+        }
       }
     }
   }

--- a/src/components/terminal/index.tsx
+++ b/src/components/terminal/index.tsx
@@ -51,6 +51,7 @@ export default function Terminal({
   const padding = " ".repeat(whitespacePadding);
   return (
     <div
+      tabIndex={0}
       className={classNames(s.terminal, className, {
         [s.fontXTiny]: fontSize === "xtiny",
         [s.fontTiny]: fontSize === "tiny",


### PR DESCRIPTION
This is super picky and more or less comes from my OCD, but I noticed that the window buttons don't match the actual default size seen on macOS (unless we're not following macOS style here, in which case this PR is moot), so I tried to make it more accurate. While at it, I also attempted a focus mode with the buttons activated.

Before (real Ghostty window for reference):

![image](https://github.com/user-attachments/assets/557b9eb9-cb64-4efe-8587-8d0b7d6316b2)

After:

![image](https://github.com/user-attachments/assets/8acf497d-1a70-468e-a4c8-70337ae78647)

When the terminal receives focus:

![image](https://github.com/user-attachments/assets/181a7848-4f70-450f-8b58-72bb35b75aab)

I'm well aware that this is super OCD and a drive-by PR, so please feel free to close it if it doesn't make any sense :)
