### PR TITLE
feat(ui): add table style (closes #28)

### DIFF
--- a/src/layouts/root-layout/RootLayout.module.css
+++ b/src/layouts/root-layout/RootLayout.module.css
@@ -6,10 +6,35 @@
   }
 
   & table {
+    --color-border: var(--gray-2);
+    --color-header-border: var(--gray-3);
+    --color-fg: var(--gray-5);
+    --color-header-fg:var(--gray-7);
+
+    display: block;
+    table-layout: auto;
+    border-collapse: collapse;
+    margin: 32px 0;
+    overflow: auto;
+
     & th, td {
-		  color: var(--gray-9);
-      text-align: left;
-      padding-right: 28px;
+		  color: var(--color-fg);
+      text-align: start;
+      padding: 10px 16px 10px 2px;
+    }
+
+    & th {
+      font-weight: 600;
+      color: var(--color-header-fg);
+      vertical-align: bottom;
+    }
+
+    & tr {
+      border-bottom: 1px solid var(--color-border);
+    }
+
+    & thead tr {
+      border-bottom-color: var(--color-header-border);
     }
   }
 }


### PR DESCRIPTION
My attempt at #28. I took inspiration from [Mintlify](https://mintlify.com/docs/advanced/widget/chat#usage) and [VitePress](https://vitepress.dev/guide/markdown#github-style-tables) with some minimal customizations to better fit the overall Ghostty doc style.

Preview:
![image](https://github.com/user-attachments/assets/e51c0c8c-d5d9-446c-9fe5-696b76290b75)


