### PR TITLE
Reveal terminal traffic light buttons on hover instead of focus

### DIFF
--- a/src/components/terminal/Terminal.module.css
+++ b/src/components/terminal/Terminal.module.css
@@ -93,7 +93,7 @@
     }
   }
 
-  &:focus {
+  &:hover {
     & .header {
       & .windowControls {
         & li:first-child {


### PR DESCRIPTION
Previously most people wouldn't even see the traffic light effect unless they accidentally clicked or whatever on the terminal animation, this is a small change to reveal them on hover instead of focus :)