### PR TITLE
Use Link in MDX content to allow for client-side navigation

### DIFF
--- a/src/components/custom-mdx/index.tsx
+++ b/src/components/custom-mdx/index.tsx
@@ -8,6 +8,7 @@ import Callout, { Note, Tip, Important, Warning, Caution } from "../callout";
 import CardLinks from "../card-links";
 import VTSequence from "../vt-sequence";
 import ButtonLinks from "../button-links";
+import Link from "next/link";
 
 interface CustomMDXProps {
   content: MDXRemoteSerializeResult;
@@ -25,6 +26,7 @@ export default function CustomMDX({ content }: CustomMDXProps) {
           h4: (props) => JumplinkHeader({ ...props, as: "h4" }),
           h5: (props) => JumplinkHeader({ ...props, as: "h5" }),
           h6: (props) => JumplinkHeader({ ...props, as: "h6" }),
+          a: Link as any,
           li: LI,
           p: BodyParagraph,
           pre: CodeBlock,


### PR DESCRIPTION
Just noticed a full page refresh when I clicked a link from content.

This switches it over to a next/link which allows for client-side routing.

A quick demo; Ghostty.org is what's on main (you will notice a page refresh where the favicon is), whereas when I do it on the PR link there's no page refresh.
https://github.com/user-attachments/assets/255bcf79-66a8-4869-a19a-61622cf6c22a


