### PR TITLE
Add icon to Edit on GitHub links

### DIFF
--- a/src/pages/docs/[...path]/DocsPage.module.css
+++ b/src/pages/docs/[...path]/DocsPage.module.css
@@ -89,4 +89,13 @@
       margin: 24px auto 54px auto;
     }
   }
+
+  .editOnGithub {
+    display: flex;
+    align-items: center;
+
+    svg {
+      margin-left: 4px;
+    }
+  }
 }

--- a/src/pages/docs/[...path]/index.tsx
+++ b/src/pages/docs/[...path]/index.tsx
@@ -12,6 +12,7 @@ import { loadDocsNavTreeData } from "@/lib/fetch-nav";
 import { navTreeToBreadcrumbs } from "@/lib/nav-tree-to-breadcrumbs";
 import s from "./DocsPage.module.css";
 import ScrollToTopButton from "@/components/scroll-to-top";
+import { Pencil } from "lucide-react";
 
 // This is the location that we expect our docs mdx files to be located,
 // relative to the root of the Next.js project.
@@ -108,8 +109,8 @@ export default function DocsPage({
           <CustomMDX content={content} />
           <br />
           <div>
-            <a href={`${GITHUB_REPO_URL}/edit/main/${relativeFilePath}`}>
-              Edit on GitHub
+            <a className={s.editOnGithub} href={`${GITHUB_REPO_URL}/edit/main/${relativeFilePath}`}>
+              Edit on GitHub <Pencil size={16} />
             </a>
           </div>
         </main>


### PR DESCRIPTION
Adds the Lucide pencil icon to the "Edit on GitHub" links at the bottom of docs pages, which helps the element stand out more.

![CleanShot 2024-12-20 at 00 21 54](https://github.com/user-attachments/assets/f4e57ea3-f16e-45cf-ac9e-7fddd55fceb4)

I do think the spacing between the last content text and this link could also be improved but maybe in another PR.