### PR TITLE
Edited footer copyright to improve copyrighting

### DIFF
--- a/src/layouts/nav-footer-layout/index.tsx
+++ b/src/layouts/nav-footer-layout/index.tsx
@@ -38,7 +38,7 @@ export default function NavFooterLayout(props: RootLayoutProps) {
             href: "/download",
           },
         ]}
-        copyright="© 2024 Mitchell H"
+        copyright="© 2024 Mitchell Hashimoto"
       />
     </RootLayout>
   );


### PR DESCRIPTION
Usually, when copyrighting, you do not put the product name, and instead, put the maker. thus, I have changed it.

pre-change:
<img width="146" alt="image" src="https://github.com/user-attachments/assets/d2052730-2e33-4274-9d81-28262e4d5bd0" />
post-change:
<img width="152" alt="image" src="https://github.com/user-attachments/assets/1cc00d13-af0c-409c-80f9-464ad6dd34a3" />