### PR TITLE
chore(docs): align content with sidebar

### DIFF
--- a/src/pages/docs/[...path]/DocsPage.module.css
+++ b/src/pages/docs/[...path]/DocsPage.module.css
@@ -11,6 +11,7 @@
 
   & .sidebar {
     width: var(--sidebar-width);
+
     @media (max-width: 784px) {
       display: none;
     }
@@ -36,7 +37,7 @@
   }
 
   & .breadcrumbsBar {
-    padding: 30px 0;
+    padding: 12px 0 30px;
     border-bottom: 1px solid var(--gray-2);
   }
 
@@ -48,6 +49,7 @@
       margin-top: 8px;
       color: var(--gray-5);
       max-width: 70%;
+
       @media(max-width: 1100px) {
         max-width: unset;
       }
@@ -79,12 +81,11 @@
   }
 
   & .contentWrapper {
-    margin: 38px auto 88px auto;
+    margin: 24px auto 88px auto;
     display: flex;
-    max-width: min(
-      calc(var(--docs-content-max-width) + var(--sidecar-width) + (2 * var(--sidecar-margin))),
-      calc(100vw - var(--sidebar-width))
-    );
+    max-width: min(calc(var(--docs-content-max-width) + var(--sidecar-width) + (2 * var(--sidecar-margin))),
+        calc(100vw - var(--sidebar-width)));
+
     @media (max-width: 784px) {
       /* This is when the sidebar goes away */
       max-width: 100%;
@@ -96,14 +97,14 @@
       flex-direction: column;
       padding: 0 24px;
       flex-grow: 1;
-      max-width: min(
-        var(--docs-content-max-width),
-        calc(100vw - var(--sidebar-width) - var(--sidecar-width) - (2 * var(--sidecar-margin)))
-      );
+      max-width: min(var(--docs-content-max-width),
+          calc(100vw - var(--sidebar-width) - var(--sidecar-width) - (2 * var(--sidecar-margin))));
+
       @media(max-width: 1276px) {
         /* This is when the sidecar goes away */
         max-width: min(var(--docs-content-max-width), calc(100vw - var(--sidebar-width)));
       }
+
       @media (max-width: 784px) {
         /* This is when the sidebar goes away */
         max-width: 100%;
@@ -117,7 +118,8 @@
       margin-top: 84px;
       height: 500px;
       background: var(--gray-2);
-      @media(max-width: 1276px){
+
+      @media(max-width: 1276px) {
         display: none;
       }
     }


### PR DESCRIPTION
### What does this do?
- Aligns the content with the sidebar 
- save w/ linting (lmk if you'd prefer me to not commit the linted changes)

### Supporting Images/video
![Screenshot 2024-12-20 at 16 02 13](https://github.com/user-attachments/assets/0270be80-06c3-408e-badc-705d4a7c9833)

https://github.com/user-attachments/assets/b40bd042-ccfe-4b34-ab7e-542ae38e6e99

### tickets
- closes #82