### PR TITLE
feat: custom next link to fix target highlight bug

### DIFF
--- a/src/components/custom-mdx/index.tsx
+++ b/src/components/custom-mdx/index.tsx
@@ -8,6 +8,7 @@ import Callout, { Note, Tip, Important, Warning, Caution } from "../callout";
 import CardLinks from "../card-links";
 import VTSequence from "../vt-sequence";
 import ButtonLinks from "../button-links";
+import HashLink from "../hashlink";
 
 interface CustomMDXProps {
   content: MDXRemoteSerializeResult;
@@ -26,6 +27,7 @@ export default function CustomMDX({ content }: CustomMDXProps) {
           h5: (props) => JumplinkHeader({ ...props, as: "h5" }),
           h6: (props) => JumplinkHeader({ ...props, as: "h6" }),
           li: LI,
+          a: HashLink as any,
           p: BodyParagraph,
           pre: CodeBlock,
           blockquote: Blockquote,

--- a/src/components/hashlink/index.tsx
+++ b/src/components/hashlink/index.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import Link, { LinkProps } from 'next/link';
+
+interface HashLinkProps extends LinkProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+const HashLink: React.FC<HashLinkProps> = ({ children, onClick, ...props }) => {
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    const href = props.href.toString();
+    const hash = href.split('#')[1];
+
+    if (hash) {
+      e.preventDefault();
+
+      // Remove the hash first to force re-trigger
+      window.location.hash = '';
+
+      // Wait for the browser to update the window.location.hash
+      setTimeout(() => {
+        window.location.hash = hash;
+      }, 0);
+    }
+
+    if (onClick) onClick(e);
+  };
+
+  return (
+    <Link {...props} onClick={handleClick}>
+      {children}
+    </Link>
+  );
+};
+
+export default HashLink;


### PR DESCRIPTION
A custom HashLink component which wraps around the next/link component. Used for the Custom MDX links.

Checks for hashes in the URL and if they exist, refresh the hash in the URL to once again trigger `:target` CSS selectors.

Possible fix for #75 .

@BrandonRomano please check this out, to be honest, it seems kind of janky but couldn't find any other way to accomplish the retrigger. The setTimeout is being used to retrigger the target when clicking on the same link multiple times. If setTimeout is removed, the highlight will not retrigger when clicking on the same link, but will when clicking on links with different hashes.

[Example.webm](https://github.com/user-attachments/assets/f2b05421-5645-48f3-9b62-80054526a0cd)
