### PR TITLE
Fix homepage 500, load platform client side

### DIFF
--- a/src/components/animated-terminal/index.tsx
+++ b/src/components/animated-terminal/index.tsx
@@ -17,7 +17,6 @@ export default function AnimatedTerminal({
   frames,
   whitespacePadding,
   frameLengthMs,
-  platformStyle,
 }: AnimatedTerminalProps) {
   const [currentFrame, setCurrentFrame] = useState(0);
   useEffect(() => {
@@ -47,7 +46,6 @@ export default function AnimatedTerminal({
       fontSize={fontSize}
       lines={frames[currentFrame]}
       disableScrolling={true}
-      platformStyle={platformStyle}
     />
   );
 }

--- a/src/components/terminal/index.tsx
+++ b/src/components/terminal/index.tsx
@@ -3,12 +3,7 @@ import React, { UIEvent, useEffect, useRef, useState } from "react";
 import { Code, P } from "../text";
 import s from "./Terminal.module.css";
 
-import {
-  X,
-  Menu,
-  Grip,
-  FolderPlus
-} from "lucide-react";
+import { X, Menu, Grip, FolderPlus } from "lucide-react";
 
 export interface TerminalProps {
   className?: string;
@@ -19,7 +14,6 @@ export interface TerminalProps {
   lines?: string[];
   whitespacePadding?: number;
   disableScrolling?: boolean;
-  platformStyle?: "macos" | "adwaita";
 }
 
 export default function Terminal({
@@ -27,12 +21,18 @@ export default function Terminal({
   rows,
   fontSize = "medium",
   className,
-  platformStyle,
   title,
   lines,
   whitespacePadding = 0,
   disableScrolling = false,
 }: TerminalProps) {
+  const [platformStyle, setPlatformStyle] = useState("macos");
+  useEffect(() => {
+    const userAgent = window?.navigator.userAgent;
+    const isLinux = /Linux/i.test(userAgent);
+    setPlatformStyle(isLinux ? "adwaita" : "macos");
+  }, []);
+
   const [autoScroll, setAutoScroll] = useState(true);
   const handleScroll = (e: UIEvent<HTMLElement>) => {
     const { scrollTop, scrollHeight, clientHeight } = e.target as HTMLElement;
@@ -61,16 +61,21 @@ export default function Terminal({
   return (
     <div
       tabIndex={0}
-      className={classNames(s.terminal, className, {
-        [s.fontXTiny]: fontSize === "xtiny",
-        [s.fontTiny]: fontSize === "tiny",
-        [s.fontSmall]: fontSize === "small",
-        [s.fontMedium]: fontSize === "medium",
-        [s.fontLarge]: fontSize === "large",
-      }, {
-        [s.adwaita]: platformStyle === "adwaita",
-        [s.macos]: platformStyle === "macos",
-      })}
+      className={classNames(
+        s.terminal,
+        className,
+        {
+          [s.fontXTiny]: fontSize === "xtiny",
+          [s.fontTiny]: fontSize === "tiny",
+          [s.fontSmall]: fontSize === "small",
+          [s.fontMedium]: fontSize === "medium",
+          [s.fontLarge]: fontSize === "large",
+        },
+        {
+          [s.adwaita]: platformStyle === "adwaita",
+          [s.macos]: platformStyle === "macos",
+        }
+      )}
       style={
         {
           "--columns": columns + 2 * whitespacePadding,
@@ -79,8 +84,8 @@ export default function Terminal({
       }
     >
       <div className={s.header}>
-        { platformStyle === "adwaita" && <AdwaitaButtons /> }
-        { platformStyle === "macos" && <MacosButtons /> }
+        {platformStyle === "adwaita" && <AdwaitaButtons />}
+        {platformStyle === "macos" && <MacosButtons />}
         <P className={s.title}>{title}</P>
       </div>
       <Code
@@ -110,25 +115,29 @@ function AdwaitaButtons() {
   // It is entirely intentional that the maximize/minimize buttons are missing.
   // Blame GNOME.
 
-  return <ul className={s.windowControls}>
-    <li className={s.circularButton}>
-      <X className={s.icon}/>
-    </li>
-    <li>
-      <Menu className={s.icon}/>
-    </li>
-    <li>
-      <Grip className={s.icon}/>
-    </li>
-    <li>
-      <FolderPlus className={s.icon}/>
-    </li>
-  </ul>
+  return (
+    <ul className={s.windowControls}>
+      <li className={s.circularButton}>
+        <X className={s.icon} />
+      </li>
+      <li>
+        <Menu className={s.icon} />
+      </li>
+      <li>
+        <Grip className={s.icon} />
+      </li>
+      <li>
+        <FolderPlus className={s.icon} />
+      </li>
+    </ul>
+  );
 }
 function MacosButtons() {
-  return <ul className={s.windowControls}>
-    <li className={s.circularButton} />
-    <li className={s.circularButton} />
-    <li className={s.circularButton} />
-  </ul>
+  return (
+    <ul className={s.windowControls}>
+      <li className={s.circularButton} />
+      <li className={s.circularButton} />
+      <li className={s.circularButton} />
+    </ul>
+  );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,6 @@
-import AnimatedTerminal, { AnimatedTerminalProps } from "@/components/animated-terminal";
+import AnimatedTerminal from "@/components/animated-terminal";
+import GridContainer from "@/components/grid-container";
+import { ButtonLink } from "@/components/link";
 import RootLayout from "@/layouts/root-layout";
 import {
   loadAllTerminalFiles,
@@ -6,29 +8,17 @@ import {
 } from "@/lib/fetch-terminal-content";
 import { useLayoutEffect, useState } from "react";
 import s from "./Home.module.css";
-import Button from "@/components/button";
-import { ButtonLink } from "@/components/link";
-import SectionWrapper from "@/components/section-wrapper";
-import GridContainer from "@/components/grid-container";
 
-export async function getServerSideProps(context: any): Promise<{ props: HomePageProps }> {
-  const userAgent = context.req.headers['user-agent'];
-
-  // TODO(pluiedev): This is a really rudimentary test, but it works for now
-  // Note that Android is also technically Linux :)
-  const isLinux = /Linux/i.test(userAgent);
-
+export async function getStaticProps() {
   return {
     props: {
       terminalData: await loadAllTerminalFiles("/home"),
-      platformStyle: isLinux ? 'adwaita' : 'macos'
     },
   };
 }
 
 interface HomePageProps {
   terminalData: TerminalsMap;
-  platformStyle: AnimatedTerminalProps['platformStyle']
 }
 
 function useWindowWidth() {
@@ -44,7 +34,7 @@ function useWindowWidth() {
   return width;
 }
 
-export default function Home({ terminalData, platformStyle }: HomePageProps) {
+export default function Home({ terminalData }: HomePageProps) {
   const animationFrames = Object.keys(terminalData)
     .filter((k) => {
       return k.startsWith("home/animation_frames");
@@ -79,7 +69,6 @@ export default function Home({ terminalData, platformStyle }: HomePageProps) {
             rows={41}
             frames={animationFrames}
             frameLengthMs={31}
-            platformStyle={platformStyle}
           />
         </section>
         <GridContainer className={s.buttonsList}>


### PR DESCRIPTION
This will cause the header to load in on android slightly after the page loads. This is not ideal but fixes an issue introduced in #80 which causes the page to 500.