### PR TITLE
feat: use semantic tags for VT sequences

### DIFF
--- a/src/components/vt-sequence/VTSequence.module.css
+++ b/src/components/vt-sequence/VTSequence.module.css
@@ -2,18 +2,35 @@
   display: flex;
   width: fit-content;
   font-family: var(--jetbrains-mono);
-  color: var(--gray-9);
-  border: 1px solid var(--gray-3);
+
   /* adjust bottom margin since there's text content and fonts have padded capsizes */
   margin: 32px 0 calc(32px - 0.5em) 0;
+  list-style: none;
+  margin: 0;
+  padding-left: 0 !important;
 
   & .vtelem {
     text-align: center;
-    padding: 10px 12px;
-    border-right: 1px solid var(--gray-3);
+    border: 1px solid var(--gray-3);
+    border-right-width: 0;
 
     &:last-child {
-      border-right: none;
+      border-right-width: 1px;
+    }
+
+    & dt, 
+    & dd {
+      padding: 5px 12px;
+    }
+
+    & dt {
+      color: var(--gray-4);
+      background: var(--gray-1);
+      border-bottom: 1px solid var(--gray-2);
+    }
+
+    & dd {
+      color: var(--gray-9);
     }
   }
 }

--- a/src/components/vt-sequence/index.tsx
+++ b/src/components/vt-sequence/index.tsx
@@ -20,14 +20,16 @@ export default function VTSequence(props: VTSequenceProps) {
   // TODO: styling if unimplemented is set
 
   return (
-    <div className={s.vtsequence}>
+    <ol className={s.vtsequence}>
       {sequenceElements.map(({ value, hex }, i) => (
-        <div key={i} className={s.vtelem}>
-          <div>{hex ? `0x${hex}` : "____"}</div>
-          <div>{value}</div>
-        </div>
+        <li key={i} className={s.vtelem}>
+          <dl>
+            <dt>{hex ? `0x${hex}` : "____"}</dt>
+            <dd>{value}</dd>
+          </dl>
+        </li>
       ))}
-    </div>
+    </ol>
   );
 }
 


### PR DESCRIPTION
Currently the VT sequence elements use `div` for everything, which is hardly optimized. This PR attempts to improve the semantics, if only subtle, by using: 

* `ol` and `li` for the sequence and its items, since they are, well, sequences
* `dl`, `dt` and `dd` for the controls and codes

While I was at it I also took the liberty to add some slight style to differentiate between elements from this:

<img width="309" alt="image" src="https://github.com/user-attachments/assets/dbfab227-bc4e-49c3-a906-4ef66916ad23" />

to this:

<img width="309" alt="image" src="https://github.com/user-attachments/assets/4ad03a9e-85a9-45d7-8b77-8276ae4aa6ae" />

Not sure if this falls into the realm of what we need right now—if not please feel free to close it.
