### PR TITLE
docs: rename Ghostty Docs to Introduction

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Ghostty Docs
+title: Introduction
 description: |-
   Ghostty is a fast, feature-rich, and cross-platform terminal emulator
   that uses platform-native UI and GPU acceleration.

--- a/src/lib/fetch-nav.ts
+++ b/src/lib/fetch-nav.ts
@@ -58,7 +58,7 @@ function contextualizeNavFile(
     {
       type: "link",
       path: "",
-      title: "Ghostty Docs",
+      title: "Introduction",
       active: activePageSlug === "index",
     },
     ...navFile.items.map(contextualizeNavTreeNode(activePageSlug, "")),

--- a/src/pages/docs/[...path]/index.tsx
+++ b/src/pages/docs/[...path]/index.tsx
@@ -48,7 +48,7 @@ export async function getStaticProps({ params: { path } }: StaticPropsParams) {
   const navTreeData = await loadDocsNavTreeData(DOCS_DIRECTORY, activePageSlug);
   const docsPageData = await loadDocsPage(DOCS_DIRECTORY, activePageSlug);
   const breadcrumbs = navTreeToBreadcrumbs(
-    "Ghostty Docs",
+    "Introduction",
     DOCS_PAGES_ROOT_PATH,
     navTreeData,
     activePageSlug


### PR DESCRIPTION
The very first page of the docs is currently titled and referenced to "Ghostty Docs," which is kind of obvious. IMHO a more fitting name could be "Introduction," which fits its content:

<img width="595" alt="image" src="https://github.com/user-attachments/assets/9c506e1d-d268-4139-8f6c-2553f0ffff56" />

As a bonus, the name would work nicely in conjunction with "About Ghostty":

<img width="354" alt="image" src="https://github.com/user-attachments/assets/fd1943fd-667b-49e4-af4a-e346f61fdda2" />
