### PR TITLE
Add prettier CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,5 +35,7 @@ jobs:
       - uses: cachix/install-nix-action@v30
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+      - name: npm install
+        run: nix develop -c npm install
       - name: prettier check
-        run: nix develop -c prettier --check .
+        run: nix develop -c npm exec -- prettier --check 'src/**/*.ts'

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -1,7 +1,6 @@
 {
   mkShell,
   alejandra,
-  nodePackages,
   bash,
   nodejs_22,
 }:
@@ -18,6 +17,5 @@ mkShell rec {
 
     # Required for CI for format checking.
     alejandra
-    nodePackages.prettier
   ];
 }


### PR DESCRIPTION
Adds a CI job for linting with prettier (this is the same as in the main ghostty repo).