### PR TITLE
feat(ui): dropdown component

### DIFF
--- a/src/components/dropdown/Dropdown.module.css
+++ b/src/components/dropdown/Dropdown.module.css
@@ -1,0 +1,117 @@
+.dropdownContainer {
+  position: relative;
+  width: max-content;
+}
+
+.trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 36px;
+  cursor: pointer;
+  user-select: none;
+  font-weight: 500;
+  border: 1px solid;
+  border-radius: var(--form-border-radius);
+  transition: border-color .15s ease, background-color .15s ease;
+  box-shadow: var(--form-box-shadow);
+
+  &.neutral {
+    color: var(--gray-9);
+    border-color: var(--gray-3);
+    background-color: var(--gray-0);
+
+    &:hover  {
+      @media(hover: hover) {
+        background-color: var(--gray-3);
+      }
+    }
+  }
+
+  &.brand {
+    border-color: var(--brand-color);
+    color: var(--gray-9);
+    background-color: var(--gray-0);
+
+    &:hover  {
+      @media(hover: hover) {
+        background-color: var(--brand-color);
+      }
+    }
+  }
+
+  &.small {
+    font-size: 12px;
+    padding: 6px;
+  }
+
+  &.medium {
+    font-size: 14px;
+    padding: 7px;
+  }
+
+  &.large {
+    font-size: 16px;
+    padding: 10px;
+  }
+
+}
+
+.icon {
+  transition: transform 0.2s ease;
+}
+
+.icon.open {
+  transform: rotate(180deg);
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background-color: var(--gray-0);
+  border: 1px solid var(--brand-color);
+  border-radius: var(--form-border-radius);
+  box-shadow: var(--form-box-shadow);
+  z-index: 10;
+}
+
+.option {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--gray-9);
+  transition: background-color .15s ease;
+  text-decoration: none;
+
+  &:hover {
+    @media(hover: hover) {
+      background-color: var(--gray-3);
+    }
+  }
+
+  &.selected {
+    background-color: var(--gray-2);
+  }
+
+  &.small {
+    font-size: 12px;
+    padding: 4px 8px;
+  }
+
+  &.medium {
+    font-size: 14px;
+    padding: 6px 12px;
+  }
+
+  &.large {
+    font-size: 16px;
+    padding: 8px 16px;
+  }
+}
+

--- a/src/components/dropdown/Dropdown.module.css
+++ b/src/components/dropdown/Dropdown.module.css
@@ -61,10 +61,10 @@
 
 .icon {
   transition: transform 0.2s ease;
-}
 
-.icon.open {
-  transform: rotate(180deg);
+  &.open {
+    transform: rotate(180deg);
+  }
 }
 
 .menu {

--- a/src/components/dropdown/Dropdown.module.css
+++ b/src/components/dropdown/Dropdown.module.css
@@ -14,7 +14,9 @@
   font-weight: 500;
   border: 1px solid;
   border-radius: var(--form-border-radius);
-  transition: border-color .15s ease, background-color .15s ease;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
   box-shadow: var(--form-box-shadow);
 
   &.neutral {
@@ -22,8 +24,8 @@
     border-color: var(--gray-3);
     background-color: var(--gray-0);
 
-    &:hover  {
-      @media(hover: hover) {
+    &:hover {
+      @media (hover: hover) {
         background-color: var(--gray-3);
       }
     }
@@ -34,8 +36,8 @@
     color: var(--gray-9);
     background-color: var(--gray-0);
 
-    &:hover  {
-      @media(hover: hover) {
+    &:hover {
+      @media (hover: hover) {
         background-color: var(--brand-color);
       }
     }
@@ -55,7 +57,6 @@
     font-size: 16px;
     padding: 10px;
   }
-
 }
 
 .icon {
@@ -86,11 +87,11 @@
   background: none;
   cursor: pointer;
   color: var(--gray-9);
-  transition: background-color .15s ease;
+  transition: background-color 0.15s ease;
   text-decoration: none;
 
   &:hover {
-    @media(hover: hover) {
+    @media (hover: hover) {
       background-color: var(--gray-3);
     }
   }
@@ -114,4 +115,3 @@
     padding: 8px 16px;
   }
 }
-

--- a/src/components/dropdown/index.tsx
+++ b/src/components/dropdown/index.tsx
@@ -1,0 +1,146 @@
+import { forwardRef, LegacyRef, useState, useRef, useEffect } from 'react';
+
+import { ChevronDown } from 'lucide-react';
+import classNames from 'classnames';
+
+import s from './Dropdown.module.css';
+import Link from 'next/link';
+
+type DropdownSize = 'small' | 'medium' | 'large';
+type DropdownTheme = 'neutral' | 'brand';
+
+interface DropdownOptionBase {
+  label: string;
+}
+
+interface DropdownOptionWithValue extends DropdownOptionBase {
+  value: string;
+  href?: never;
+}
+
+interface DropdownOptionWithLink extends DropdownOptionBase {
+  href: string;
+  value?: never;
+}
+
+type DropdownOption = DropdownOptionWithValue | DropdownOptionWithLink;
+
+
+interface DropdownProps {
+  options: DropdownOption[];
+  value?: string;
+  onChange?: (value: string) => void;
+  placeholder?: string;
+  size?: DropdownSize;
+  theme?: DropdownTheme;
+  className?: string;
+  width?: string;
+}
+
+function Dropdown(
+  {
+    options,
+    value,
+    onChange,
+    placeholder = 'Select option',
+    size = 'medium',
+    theme = 'brand',
+    className,
+    width,
+  }: DropdownProps,
+  ref?: LegacyRef<HTMLDivElement>
+) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const selectedOption = options.find(opt => opt.value === value);
+
+  const handleSelect = (option: DropdownOption) => {
+    if ('value' in option && option.value) {
+      onChange?.(option.value);
+    }
+
+    setIsOpen(false);
+  }
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  return (
+    <div
+      ref={(node) => {
+        if (typeof ref === 'function') ref(node);
+        else if (ref) ref.current = node;
+        if (dropdownRef) dropdownRef.current = node;
+      }}
+      className={classNames(s.dropdownContainer, className)}
+      style={width ? { width } : undefined}
+    >
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className={classNames(s.trigger, {
+          [s.small]: size === 'small',
+          [s.medium]: size === 'medium',
+          [s.large]: size === 'large',
+          [s.neutral]: theme === 'neutral',
+          [s.brand]: theme === 'brand',
+        })}
+      >
+        <span>{selectedOption?.label || placeholder}</span>
+        <ChevronDown
+          className={classNames(s.icon, { [s.open]: isOpen })}
+          size={size === 'small' ? 14 : size === 'medium' ? 16 : 18}
+        />
+      </button>
+
+{isOpen && (
+        <div className={s.menu}>
+          {options.map((option) => {
+            const optionClasses = classNames(s.option, {
+              [s.selected]: 'value' in option ? option.value === value : false,
+              [s.small]: size === 'small',
+              [s.medium]: size === 'medium',
+              [s.large]: size === 'large',
+            });
+
+            if ('href' in option && option.href) {
+              return (
+                <Link
+                  key={option.href}
+                  href={option.href}
+                  className={optionClasses}
+                  onClick={() => handleSelect(option)}
+                >
+                  {option.label}
+                </Link>
+              );
+            }
+
+            return (
+              <button
+                key={option.value}
+                type="button"
+                className={optionClasses}
+                onClick={() => handleSelect(option)}
+              >
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+    </div>
+  );
+}
+
+export default forwardRef(Dropdown);

--- a/src/pages/download/index.tsx
+++ b/src/pages/download/index.tsx
@@ -5,11 +5,12 @@ import { H1, H2, P } from "@/components/text";
 import NavFooterLayout from "@/layouts/nav-footer-layout";
 import { fetchLatestGhosttyVersion } from "@/lib/fetch-latest-ghostty-version";
 import { loadDocsNavTreeData } from "@/lib/fetch-nav";
-import { CodeXml, Download, Package } from "lucide-react";
+import { CodeXml, Download } from "lucide-react";
 import Image from "next/image";
 import SVGIMG from "../../../public/ghostty-logo.svg";
 import { DOCS_DIRECTORY } from "../docs/[...path]";
 import s from "./DownloadPage.module.css";
+import Dropdown from "@/components/dropdown";
 
 export async function getStaticProps() {
   return {
@@ -62,12 +63,15 @@ export default function DownloadPage({
               description="Choose a pre-built package for quick setup on your Linux distribution, or build source for complete control."
             >
               <div className={s.linuxLinks}>
-                <ButtonLink
+                <Dropdown
+                  options={[
+                    { href: 'debian', label: 'Debian' },
+                    { href: 'arch', label: 'Arch' },
+                    { href: 'source', label: 'Source' },
+                  ]}
+                  placeholder="Select distribution"
                   size="large"
-                  href="/docs/install/binary#linux"
-                  text="Package Manager"
-                  icon={<Package strokeWidth={2} size={18} />}
-                  showExternalIcon={false}
+                  width="228px"
                 />
                 <ButtonLink
                   size="large"

--- a/src/pages/download/index.tsx
+++ b/src/pages/download/index.tsx
@@ -5,12 +5,11 @@ import { H1, H2, P } from "@/components/text";
 import NavFooterLayout from "@/layouts/nav-footer-layout";
 import { fetchLatestGhosttyVersion } from "@/lib/fetch-latest-ghostty-version";
 import { loadDocsNavTreeData } from "@/lib/fetch-nav";
-import { CodeXml, Download } from "lucide-react";
+import { CodeXml, Download, Package } from "lucide-react";
 import Image from "next/image";
 import SVGIMG from "../../../public/ghostty-logo.svg";
 import { DOCS_DIRECTORY } from "../docs/[...path]";
 import s from "./DownloadPage.module.css";
-import Dropdown from "@/components/dropdown";
 
 export async function getStaticProps() {
   return {
@@ -63,15 +62,12 @@ export default function DownloadPage({
               description="Choose a pre-built package for quick setup on your Linux distribution, or build source for complete control."
             >
               <div className={s.linuxLinks}>
-                <Dropdown
-                  options={[
-                    { href: 'debian', label: 'Debian' },
-                    { href: 'arch', label: 'Arch' },
-                    { href: 'source', label: 'Source' },
-                  ]}
-                  placeholder="Select distribution"
+                <ButtonLink
                   size="large"
-                  width="228px"
+                  href="/docs/install/binary#linux"
+                  text="Package Manager"
+                  icon={<Package strokeWidth={2} size={18} />}
+                  showExternalIcon={false}
                 />
                 <ButtonLink
                   size="large"


### PR DESCRIPTION
Type-safe dropdown component following the styleguide and colorscheme of the other components.

Allows for both single option select as with a normal dropdown and for link navigation which solves issue #97.

Switching between option select and link navigation is done automatically based on the options array sent to the dropdown as a prop. The placeholders, size, theme, etc.. are also customizable via props as with other components.

Currently, the dropdown is not implemented on the download page, cause I want @mitchellh and @BrandonRomano to check it out for any styling issues or other bugs.