### PR TITLE
fix: correct usage of DECST8C

### DIFF
--- a/docs/vt/csi/cbt.mdx
+++ b/docs/vt/csi/cbt.mdx
@@ -24,7 +24,7 @@ of 8 spaces is most common.
 ### CBT V-1: Left Beyond First Column
 
 ```bash
-printf "\033[?W" # reset tab stops
+printf "\033[?5W" # reset tab stops
 printf "\033[10Z"
 printf "A"
 ```
@@ -36,7 +36,7 @@ printf "A"
 ### CBT V-2: Left Starting After Tab Stop
 
 ```bash
-printf "\033[?W" # reset tab stops
+printf "\033[?5W" # reset tab stops
 printf "\033[1;10H"
 printf "X"
 printf "\033[Z"
@@ -50,7 +50,7 @@ printf "A"
 ### CBT V-3: Left Starting on Tabstop
 
 ```bash
-printf "\033[?W" # reset tab stops
+printf "\033[?5W" # reset tab stops
 printf "\033[1;9H"
 printf "X"
 printf "\033[1;9H"
@@ -67,7 +67,7 @@ printf "A"
 ```bash
 printf "\033[1;1H" # move to top-left
 printf "\033[0J" # clear screen
-printf "\033[?W" # reset tab stops
+printf "\033[?5W" # reset tab stops
 printf "\033[?6h" # enable origin mode
 printf "\033[?69h" # enable left/right margins
 printf "\033[3;6s" # scroll region left/right

--- a/docs/vt/csi/cht.mdx
+++ b/docs/vt/csi/cht.mdx
@@ -27,7 +27,7 @@ of 8 spaces is most common.
 ### CHT V-1: Right Beyond Last Column
 
 ```bash
-printf "\033[?W" # reset tab stops
+printf "\033[?5W" # reset tab stops
 printf "\033[100I" # assuming the test terminal has less than 800 columns
 printf "A"
 ```
@@ -39,7 +39,7 @@ printf "A"
 ### CHT V-2: Right From Before a Tabstop
 
 ```bash
-printf "\033[?W" # reset tab stops
+printf "\033[?5W" # reset tab stops
 printf "\033[1;2H"
 printf "A"
 printf "\033[I"
@@ -55,7 +55,7 @@ printf "X"
 ```bash
 printf "\033[1;1H" # move to top-left
 printf "\033[0J" # clear screen
-printf "\033[?W" # reset tab stops
+printf "\033[?5W" # reset tab stops
 printf "\033[?69h" # enable left/right margins
 printf "\033[3;6s" # scroll region left/right
 printf "\033[1;1H" # move cursor in region

--- a/docs/vt/csi/tbc.mdx
+++ b/docs/vt/csi/tbc.mdx
@@ -19,7 +19,7 @@ If the parameter `n` is `3`, all tab stops are cleared.
 ```bash
 printf "\033[1;1H" # move to top-left
 printf "\033[0J" # clear screen
-printf "\033[?W" # reset tabs
+printf "\033[?5W" # reset tabs
 printf "\t"
 printf "\033[g"
 printf "\033[1G"
@@ -35,7 +35,7 @@ printf "\t"
 ```bash
 printf "\033[1;1H" # move to top-left
 printf "\033[0J" # clear screen
-printf "\033[?W" # reset tabs
+printf "\033[?5W" # reset tabs
 printf "\033[3g"
 printf "\033[1G"
 printf "\t"


### PR DESCRIPTION
Use DECST8C `CSI ? 5 W` to reset tab stops.

See: https://github.com/ghostty-org/ghostty/commit/3356ce18d12f17b405a059abe8bac6d43a39c687