### PR TITLE
Make path easy to copy & paste

### DIFF
--- a/docs/config/index.mdx
+++ b/docs/config/index.mdx
@@ -40,7 +40,7 @@ The configuration file is loaded from the following locations:
 - `$XDG_CONFIG_HOME/ghostty/config` (all platforms). If `XDG_CONFIG_HOME`
   is not set, it defaults to `$HOME/.config`.
 
-- `~/Library/Application Support/com.mitchellh.ghostty/config` (macOS only).
+- `~/Library/Application\ Support/com.mitchellh.ghostty/config` (macOS only).
   macOS also supports the XDG location.
 
 If both locations exist, they are loaded in the order above


### PR DESCRIPTION
A space considered as a separator between CLI arguments.
This should make Copy&Paste easier.