### PR TITLE
feat: add search bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ghostty-website",
       "version": "0.1.0",
       "dependencies": {
+        "@docsearch/react": "^3.8.2",
         "@r4ai/remark-callout": "^0.6.2",
         "classnames": "^2.5.1",
         "gray-matter": "^4.0.3",
@@ -35,6 +36,214 @@
         "eslint-config-next": "14.2.5",
         "prettier": "3.4.2",
         "typescript": "5.5.4"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.18.0.tgz",
+      "integrity": "sha512-DLIrAukjsSrdMNNDx1ZTks72o4RH/1kOn8Wx5zZm8nnqFexG+JzY4SANnCNEjnFQPJTTvC+KpgiNW/CP2lumng==",
+      "dependencies": {
+        "@algolia/client-common": "5.18.0",
+        "@algolia/requester-browser-xhr": "5.18.0",
+        "@algolia/requester-fetch": "5.18.0",
+        "@algolia/requester-node-http": "5.18.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.18.0.tgz",
+      "integrity": "sha512-0VpGG2uQW+h2aejxbG8VbnMCQ9ary9/ot7OASXi6OjE0SRkYQ/+pkW+q09+IScif3pmsVVYggmlMPtAsmYWHng==",
+      "dependencies": {
+        "@algolia/client-common": "5.18.0",
+        "@algolia/requester-browser-xhr": "5.18.0",
+        "@algolia/requester-fetch": "5.18.0",
+        "@algolia/requester-node-http": "5.18.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.18.0.tgz",
+      "integrity": "sha512-X1WMSC+1ve2qlMsemyTF5bIjwipOT+m99Ng1Tyl36ZjQKTa54oajBKE0BrmM8LD8jGdtukAgkUhFoYOaRbMcmQ==",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.18.0.tgz",
+      "integrity": "sha512-FAJRNANUOSs/FgYOJ/Njqp+YTe4TMz2GkeZtfsw1TMiA5mVNRS/nnMpxas9771aJz7KTEWvK9GwqPs0K6RMYWg==",
+      "dependencies": {
+        "@algolia/client-common": "5.18.0",
+        "@algolia/requester-browser-xhr": "5.18.0",
+        "@algolia/requester-fetch": "5.18.0",
+        "@algolia/requester-node-http": "5.18.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.18.0.tgz",
+      "integrity": "sha512-I2dc94Oiwic3SEbrRp8kvTZtYpJjGtg5y5XnqubgnA15AgX59YIY8frKsFG8SOH1n2rIhUClcuDkxYQNXJLg+w==",
+      "dependencies": {
+        "@algolia/client-common": "5.18.0",
+        "@algolia/requester-browser-xhr": "5.18.0",
+        "@algolia/requester-fetch": "5.18.0",
+        "@algolia/requester-node-http": "5.18.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.18.0.tgz",
+      "integrity": "sha512-x6XKIQgKFTgK/bMasXhghoEjHhmgoP61pFPb9+TaUJ32aKOGc65b12usiGJ9A84yS73UDkXS452NjyP50Knh/g==",
+      "dependencies": {
+        "@algolia/client-common": "5.18.0",
+        "@algolia/requester-browser-xhr": "5.18.0",
+        "@algolia/requester-fetch": "5.18.0",
+        "@algolia/requester-node-http": "5.18.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.18.0.tgz",
+      "integrity": "sha512-qI3LcFsVgtvpsBGR7aNSJYxhsR+Zl46+958ODzg8aCxIcdxiK7QEVLMJMZAR57jGqW0Lg/vrjtuLFDMfSE53qA==",
+      "dependencies": {
+        "@algolia/client-common": "5.18.0",
+        "@algolia/requester-browser-xhr": "5.18.0",
+        "@algolia/requester-fetch": "5.18.0",
+        "@algolia/requester-node-http": "5.18.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.18.0.tgz",
+      "integrity": "sha512-bGvJg7HnGGm+XWYMDruZXWgMDPVt4yCbBqq8DM6EoaMBK71SYC4WMfIdJaw+ABqttjBhe6aKNRkWf/bbvYOGyw==",
+      "dependencies": {
+        "@algolia/client-common": "5.18.0",
+        "@algolia/requester-browser-xhr": "5.18.0",
+        "@algolia/requester-fetch": "5.18.0",
+        "@algolia/requester-node-http": "5.18.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.18.0.tgz",
+      "integrity": "sha512-lBssglINIeGIR+8KyzH05NAgAmn1BCrm5D2T6pMtr/8kbTHvvrm1Zvcltc5dKUQEFyyx3J5+MhNc7kfi8LdjVw==",
+      "dependencies": {
+        "@algolia/client-common": "5.18.0",
+        "@algolia/requester-browser-xhr": "5.18.0",
+        "@algolia/requester-fetch": "5.18.0",
+        "@algolia/requester-node-http": "5.18.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.18.0.tgz",
+      "integrity": "sha512-uSnkm0cdAuFwdMp4pGT5vHVQ84T6AYpTZ3I0b3k/M3wg4zXDhl3aCiY8NzokEyRLezz/kHLEEcgb/tTTobOYVw==",
+      "dependencies": {
+        "@algolia/client-common": "5.18.0",
+        "@algolia/requester-browser-xhr": "5.18.0",
+        "@algolia/requester-fetch": "5.18.0",
+        "@algolia/requester-node-http": "5.18.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.18.0.tgz",
+      "integrity": "sha512-1XFjW0C3pV0dS/9zXbV44cKI+QM4ZIz9cpatXpsjRlq6SUCpLID3DZHsXyE6sTb8IhyPaUjk78GEJT8/3hviqg==",
+      "dependencies": {
+        "@algolia/client-common": "5.18.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.18.0.tgz",
+      "integrity": "sha512-0uodeNdAHz1YbzJh6C5xeQ4T6x5WGiUxUq3GOaT/R4njh5t78dq+Rb187elr7KtnjUmETVVuCvmEYaThfTHzNg==",
+      "dependencies": {
+        "@algolia/client-common": "5.18.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.18.0.tgz",
+      "integrity": "sha512-tZCqDrqJ2YE2I5ukCQrYN8oiF6u3JIdCxrtKq+eniuLkjkO78TKRnXrVcKZTmfFJyyDK8q47SfDcHzAA3nHi6w==",
+      "dependencies": {
+        "@algolia/client-common": "5.18.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1103,6 +1312,42 @@
         "postcss": "^8.4"
       }
     },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ=="
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -1807,6 +2052,29 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.18.0.tgz",
+      "integrity": "sha512-/tfpK2A4FpS0o+S78o3YSdlqXr0MavJIDlFK3XZrlXLy7vaRXJvW5jYg3v5e/wCaF8y0IpMjkYLhoV6QqfpOgw==",
+      "dependencies": {
+        "@algolia/client-abtesting": "5.18.0",
+        "@algolia/client-analytics": "5.18.0",
+        "@algolia/client-common": "5.18.0",
+        "@algolia/client-insights": "5.18.0",
+        "@algolia/client-personalization": "5.18.0",
+        "@algolia/client-query-suggestions": "5.18.0",
+        "@algolia/client-search": "5.18.0",
+        "@algolia/ingestion": "1.18.0",
+        "@algolia/monitoring": "1.18.0",
+        "@algolia/recommend": "5.18.0",
+        "@algolia/requester-browser-xhr": "5.18.0",
+        "@algolia/requester-fetch": "5.18.0",
+        "@algolia/requester-node-http": "5.18.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/ansi-regex": {
@@ -7311,6 +7579,12 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "peer": true
     },
     "node_modules/section-matter": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint && prettier 'src/**/*.ts' --write"
   },
   "dependencies": {
+    "@docsearch/react": "^3.8.2",
     "@r4ai/remark-callout": "^0.6.2",
     "classnames": "^2.5.1",
     "gray-matter": "^4.0.3",

--- a/src/components/navbar/Navbar.module.css
+++ b/src/components/navbar/Navbar.module.css
@@ -117,3 +117,16 @@
     }
   }
 }
+
+.search {
+  width: 50%;
+
+  & :global(.DocSearch) {
+    width: 100%;
+  }
+
+  & :global(.DocSearch-Button){
+    border: 1px solid var(--brand-color);
+    border-radius: 10px;
+  }
+}

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -8,7 +8,9 @@ import GridContainer, { NavAndFooterGridConfig } from "../grid-container";
 import Link, { ButtonLink, SimpleLink } from "../link";
 import NavTree, { BreakNode, LinkNode, NavTreeNode } from "../nav-tree";
 import GhosttyWordmark from "./ghostty-wordmark.svg";
+import '@docsearch/css';
 import s from "./Navbar.module.css";
+import { DocSearch } from "@docsearch/react"
 import { useRouter } from "next/router";
 
 export interface NavbarProps {
@@ -94,6 +96,13 @@ export default function Navbar({
         <NextLink href="/">
           <Image src={GhosttyWordmark} alt="Ghostty" />
         </NextLink>
+      <div className={s.search}>
+      <DocSearch
+        appId="PVKTWXOYZX"
+        indexName="ghostty"
+        apiKey="4b2b0f475ce709fe29e07740b277de61"
+      />
+      </div>
         <div className={s.desktopLinks}>
           {links && (
             <ul className={s.linkList}>

--- a/src/layouts/root-layout/index.tsx
+++ b/src/layouts/root-layout/index.tsx
@@ -43,6 +43,8 @@ export default function RootLayout({
         <link rel="icon" type="image/png" sizes="16x16" href="favicon-16.png" />
         <link rel="shortcut icon" href="/favicon.ico" />
         <meta property="og:image" content="/social-share-card.jpg" />
+
+        <link rel="preconnect" href="https://PVKTWXOYZX-dsn.algolia.net" crossOrigin="anonymous" />
       </Head>
       {children}
     </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -50,6 +50,23 @@ body {
     rgba(0, 0, 0, 0) 0px 0px 0px 0px,
     rgba(55, 55, 55, 0.15) 0px 1px 2px 0px;
 
+  --docsearch-text-color: var(--gray-4);
+  --docsearch-container-background: var(--gray-0);
+  --docsearch-modal-background: var(--gray-0);
+  --docsearch-modal-shadow: inset 1px 1px 0 0 rgb(44, 46, 64), 0 3px 8px 0 rgb(0, 3, 9);
+  --docsearch-searchbox-background: var(--gray-0);
+  --docsearch-searchbox-focus-background: var(--gray-0);
+  --docsearch-highlight-color: var(--brand-color);
+  --docsearch-hit-color: var(--gray-4);
+  --docsearch-hit-shadow: none;
+  --docsearch-hit-background: var(--gray-1);
+  --docsearch-key-gradient: linear-gradient( -26.5deg, var(--brand-color) 0%, rgb(49, 53, 91) 100%);
+  --docsearch-key-shadow: inset 0 -2px 0 0 rgb(40, 45, 85), inset 0 0 1px 1px rgb(81, 87, 125), 0 2px 2px 0 rgba(3, 4, 9, 0.3);
+  --docsearch-key-pressed-shadow: inset 0 -2px 0 0 #282d55, inset 0 0 1px 1px #51577d, 0 1px 1px 0 #0304094d;
+  --docsearch-footer-background: var(--gray-0);
+  --docsearch-footer-shadow: inset 0 1px 0 0 rgba(73, 76, 106, 0.5), 0 -4px 8px 0 rgba(0, 0, 0, 0.2);
+  --docsearch-muted-color: var(--gray-4);
+
   --atom-one-blue: #61aeee;
   --atom-one-green: #98c379;
   --atom-one-yellow: #e6c07b;
@@ -144,3 +161,4 @@ body {
 .hljs-link {
   text-decoration: underline;
 }
+


### PR DESCRIPTION
Hey, congrats on the launch, I was really looking forward to it and so far it's been a great and easy setup experience!

I was browsing the doc for shell integrations with fish and realized there was no search capabilities. I've been contributing to [DocSearch](https://docsearch.algolia.com/) for a while now and thought you might be interested on adding it to your documentation (well written btw, super easy to crawl :)), so I've made a small POC.

(The API key is search only and public, no worries about disclosing it, also don't mind the font issue I did not managed to import yours for some reason, I don't have much nextjs knowledge)

## UI

Here's a small preview:

| Desktop | Mobile |
|--------|--------|
| <img width="1490" alt="Screenshot 2024-12-26 at 22 59 35" src="https://github.com/user-attachments/assets/f11bb0e1-cbc8-44e8-a9fe-12c220058b30" /> | <img width="383" alt="Screenshot 2024-12-26 at 23 00 22" src="https://github.com/user-attachments/assets/cad9af1a-3251-4ff6-a640-b6efefe64081" /> |
| <img width="1484" alt="Screenshot 2024-12-26 at 22 59 55" src="https://github.com/user-attachments/assets/a6f765af-03af-4d05-9bce-c4d59f30eb7d" /> | <img width="375" alt="Screenshot 2024-12-26 at 23 01 01" src="https://github.com/user-attachments/assets/d14d2299-7b44-4e79-84fb-4ba6483fd534" /> |

## Search results relevancy

I've built this index with our default "fit all" crawler logic, but many tweaks could be done like increasing the weight of results from the `option reference` pages, exclude pages that are less important (e.g. homepage), etc.