### PR TITLE
Can ignore: older tic versions may treat the description field as an alias

### DIFF
--- a/docs/help/terminfo.mdx
+++ b/docs/help/terminfo.mdx
@@ -59,9 +59,9 @@ import it on the remote machine:
 infocmp -x | ssh YOUR-SERVER -- tic -x -
 ```
 
-The ``tic`` command on the server may give the warning ``"<stdin>", line 2,
+The `tic` command on the server may give the warning `"<stdin>", line 2,
 col 31, terminal 'xterm-ghostty': older tic versions may treat the description
-field as an alias`` which can be ignored.
+field as an alias` which can be safely ignored.
 
 <Note>
 **macOS versions before Sonoma cannot use the system-bundled `infocmp`.**

--- a/docs/help/terminfo.mdx
+++ b/docs/help/terminfo.mdx
@@ -59,6 +59,10 @@ import it on the remote machine:
 infocmp -x | ssh YOUR-SERVER -- tic -x -
 ```
 
+The ``tic`` command on the server may give the warning ``"<stdin>", line 2,
+col 31, terminal 'xterm-ghostty': older tic versions may treat the description
+field as an alias`` which can be ignored.
+
 <Note>
 **macOS versions before Sonoma cannot use the system-bundled `infocmp`.**
 The bundled version of `ncurses` is too old to emit a terminfo entry that can be


### PR DESCRIPTION
Mention a common but harmless warning from the infocomp/tic command for configuring terminfo on a remote server.

I had this with three different remote systems, and it appeared from other people on the Discord.