### PR TITLE
Add direct link to git repo from source build docs

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -13,6 +13,12 @@ instead. See [the binaries and packages page](/docs/install/binary) to
 see if a prebuilt binary or package is available for your platform.
 </Tip>
 
+Clone the Ghostty source code from GitHub:
+
+```shell-session
+git clone https://github.com/ghostty-org/ghostty.git
+```
+
 To build Ghostty, you need [Zig 0.13](https://ziglang.org/) installed.
 
 <Important>


### PR DESCRIPTION
Thanks! I've been looking forward to the release of Ghostty for while (using native tabs is a big draw for me). Nice work!

I noticed that neither the [Download page](https://ghostty.org/download), nor the [Build from Source page](https://ghostty.org/docs/install/build) included a link to the github repo. I spent a few minutes on the later looking for a link to the repo that I'd need to clone. Eventually I found it and later realized that I'd missed a discrete little link to GitHub in the nav bar at the top.

Hopefully adding the address of the repo to the body text of the Build from Source page will save some trouble for anyone else who's quickly skimming that page (or searching the page for the keyword "clone" like I was).