### PR TITLE
Remove `--cask` from `brew install`.

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -25,7 +25,7 @@ process as installing many typical macOS applications.
 A Homebrew cask is available and maintained by the community.
 
 ```bash
-brew install --cask ghostty
+brew install ghostty
 ```
 
 ## Linux


### PR DESCRIPTION
`brew` will install `ghostty` correctly without the `--cask` argument. Just `brew install ghostty`, it's cleaner.

(Thank you for ghostty).