### PR TITLE
Implement darkreader lock

### DIFF
--- a/src/layouts/root-layout/index.tsx
+++ b/src/layouts/root-layout/index.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
         s.rootLayout,
         pretendardVariable.variable,
         jetbrainsMono.variable,
-        className
+        className,
       )}
     >
       <Head>
@@ -43,6 +43,8 @@ export default function RootLayout({
         <link rel="icon" type="image/png" sizes="16x16" href="favicon-16.png" />
         <link rel="shortcut icon" href="/favicon.ico" />
         <meta property="og:image" content="/social-share-card.jpg" />
+
+        <meta name="darkreader-lock" />
       </Head>
       {children}
     </div>


### PR DESCRIPTION
# Issue:
When using Darkreader, parts of the website render with bad color schemes and contrast ratios

# Suggested Solution:
Implement a `darkreader-lock` meta tag within `src/layouts/root-layout/index.tsx` so it exists globally across the site

Resolves #150 