### PR TITLE
Fix Typos

### DIFF
--- a/docs/about.mdx
+++ b/docs/about.mdx
@@ -55,7 +55,7 @@ equivalents in Linux desktop environments.
 ## Feature-rich
 
 Ghostty tries to provide a rich set of features that are useful
-for everydays use. These can be split into two categories:
+for everyday use. These can be split into two categories:
 terminal features and application features.
 
 Terminal features include the capabilities that programs running

--- a/docs/config/keybind/sequence.mdx
+++ b/docs/config/keybind/sequence.mdx
@@ -7,7 +7,7 @@ description: |-
 Ghostty supports keybindings that require a sequence of triggers
 to activate the action. For example, you could require `ctrl+a`
 followed by `n` to open a new window. In other software, this is sometimes
-referred to as a "leader key", a "key choord", a "key table",
+referred to as a "leader key", a "key chord", a "key table",
 etc.
 
 To specify a sequence of triggers, use the

--- a/docs/config/reference.mdx
+++ b/docs/config/reference.mdx
@@ -654,7 +654,7 @@ other behaviors as well:
     (i.e. by wrapping your command in a shell, setting env vars, etc.).
     This is a safety measure to prevent unexpected behavior. If you want
     shell integration with a `-e`-executed command, you must either
-    name your binary appopriately or source the shell integration script
+    name your binary appropriately or source the shell integration script
     manually.
 
 

--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -135,7 +135,7 @@ enabled).
 
 If you use [`nix-direnv`](https://github.com/nix-community/nix-direnv),
 Ghostty provides an `.envrc` file you can source by running `direnv allow`.
-This will allow you to seemlessly enter and exit the Ghostty development
+This will allow you to seamlessly enter and exit the Ghostty development
 environment as you enter and exit the Ghostty repository. Direnv is not
 required.
 

--- a/docs/install/pre.mdx
+++ b/docs/install/pre.mdx
@@ -51,7 +51,7 @@ setting! This setting does not take effect until Ghostty is restarted.
 While you can set this setting back to `stable` at any time, this will
 only take effect when a later stable release is available. If you want
 to downgrade back to the previous stable release, you must
-[redownload](/download) Ghostty.
+[re-download](/download) Ghostty.
 </Warning>
 
 <Note>


### PR DESCRIPTION
Fixes the following typos in the following files
- everydays 🡒 everyday in `docs/about.mdx`
- seemlessly 🡒 seamlessly in `docs/install/build.mdx`
- redownload 🡒 re-download in `docs/install/pre.mdx`
- appopriately 🡒 appropriately in `docs/config/reference.mdx`
- key choord 🡒 key chord in `docs/config/keybind/sequence.mdx`