### PR TITLE
remove dollar sign prefix from command block

### DIFF
--- a/docs/features/theme.mdx
+++ b/docs/features/theme.mdx
@@ -32,7 +32,7 @@ Ghostty.
 To see a list of available themes, you can use the `+list-themes` CLI:
 
 ```sh
-$ ghostty +list-themes
+ghostty +list-themes
 ```
 
 For built-in themes, you can also view the theme list online


### PR DESCRIPTION
Remove unnecessary $ prefix from command code blocks for better user experience. This change allows users to directly copy-paste commands without having to manually remove the $ symbol.