### PR TITLE
Fix safari navbar overflow issue

### DIFF
--- a/src/components/navbar/Navbar.module.css
+++ b/src/components/navbar/Navbar.module.css
@@ -48,7 +48,7 @@
       display: block;
     }
     background: var(--gray-0);
-    height: calc(100vh - var(--header-height));
+    height: calc(100dvh - var(--header-height));
     border-top: 1px solid var(--gray-2);
     padding: 24px;
   }


### PR DESCRIPTION
RE: #153.  It looks like in Safari mobile `vh` calculation includes the address bar.  Using `dvh` seems to fix this one.


<img src="https://github.com/user-attachments/assets/207cc821-5279-40a2-9851-adf427642dc6" width="300px" />
