### PR TITLE
mention pkg-config when building for linux

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -56,12 +56,14 @@ use them for development.
 #### Dependencies
 
 On Linux, you'll need to install header packages for Ghostty's dependencies
-before building it. Typically, these are only `gtk4` and `libadwaita`, since
-Ghostty will build everything else static by default.
+before building it. Only a few dependencies are needed for source builds
+because Ghostty will build everything else statically by default.
 
-<Note>
-`pkg-config` may be required if your system does not detect `gtk4` and `libadwaita`.
-</Note>
+Required dependencies:
+
+  * `gtk4`
+  * `libadwaita`
+  * `pkg-config`
 
 On Ubuntu and Debian, use:
 

--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -56,8 +56,12 @@ use them for development.
 #### Dependencies
 
 On Linux, you'll need to install header packages for Ghostty's dependencies
-before building it. Typically, these are only gtk4 and libadwaita, since
+before building it. Typically, these are only `gtk4` and `libadwaita`, since
 Ghostty will build everything else static by default.
+
+<Note>
+`pkg-config` may be required if your system does not detect `gtk4` and `libadwaita`.
+</Note>
 
 On Ubuntu and Debian, use:
 


### PR DESCRIPTION
Distros such as Void Linux require `pkg-config` to detect `gtk4` and `libadwaita`.