### PR TITLE
adjust wrapping to remove extra space from paths

### DIFF
--- a/docs/config/reference.mdx
+++ b/docs/config/reference.mdx
@@ -355,10 +355,10 @@ configuration directory. This is `$XDG_CONFIG_DIR/ghostty/themes` or
 
 The second directory is the `themes` subdirectory of the Ghostty resources
 directory. Ghostty ships with a multitude of themes that will be installed
-into this directory. On macOS, this list is in the `Ghostty.app/Contents/
-Resources/ghostty/themes` directory. On Linux, this list is in the `share/
-ghostty/themes` directory (wherever you installed the Ghostty "share"
-directory.
+into this directory. On macOS, this list is in the
+`Ghostty.app/Contents/Resources/ghostty/themes` directory. On Linux, this
+list is in the `share/ghostty/themes` directory (wherever you installed the
+Ghostty "share" directory.
 
 To see a list of available themes, run `ghostty +list-themes`.
 


### PR DESCRIPTION
It seems that hardwrapping when the newline happens to be inside of an inline code span is causing an extra space to show up in the rendered version. For example, I noticed this issue after copy-pasting `Ghosttty.app/Contents/ Resources/ghostty/themes` from the docs (notice the extra space before `Resources`).

There might be other cases in the docs where wrapping is similarly a problem, I just happened to notice these two.