### PR TITLE
close border gap on adwaita terminal header

### DIFF
--- a/src/components/terminal/Terminal.module.css
+++ b/src/components/terminal/Terminal.module.css
@@ -56,7 +56,7 @@
     display: grid;
     align-items: center;
     position: relative;
-    border-radius: 10px 10px 0px 0px;
+    border-radius: 9px 9px 0px 0px;
     padding: var(--padding);
 
     grid-template: "controls title .";


### PR DESCRIPTION
The border radius of the adwaita terminal header bar is the same as its parent causing this gap. Subtracting the thickness of the border from the radius closes the gap.

before:
<img width="861" alt="image" src="https://github.com/user-attachments/assets/91a022fa-7bbb-4282-9ac7-9ba5e1a6b048" />
after:
<img width="770" alt="image" src="https://github.com/user-attachments/assets/9cc6a07b-b4e9-44ce-995d-a69648cef058" />
