### PR TITLE
[Behaviour] macos-tiling-wms.mdx: change layout to "tiling" to make shortcuts consistent with other open windows in the window manager

### DIFF
--- a/docs/help/macos-tiling-wms.mdx
+++ b/docs/help/macos-tiling-wms.mdx
@@ -35,7 +35,7 @@ depending on the tiling window manager you are using.
 [[on-window-detected]]
 if.app-id="com.mitchellh.ghostty"
 run= [
-  "layout floating",
+  "layout tiling",
 ]
 ```
 


### PR DESCRIPTION
When using "floating" layout, new windows created using "cmd+n" didn't recognise tiling commands like "alt+l" or "alt+h" to move it front and back. Only the first window created was being controlled like other tiling windows. It may be because floating windows aren't part of tiling tree.

The same thing happened to me with Kitty and the following config makes it work like how other windows in the aerospace tree work.

Here is the config that can be a sane default

```toml
[[on-window-detected]]
if.app-id="com.mitchellh.ghostty"
run= [ "layout tiling" ]
```


Closes https://github.com/ghostty-org/website/issues/163