### PR TITLE
feat(generic-card): make generic card from download card

### DIFF
--- a/src/components/generic-card/GenericCard.module.css
+++ b/src/components/generic-card/GenericCard.module.css
@@ -1,5 +1,4 @@
 .genericCard {
-  padding: 58px;
   border: 1px solid var(--gray-2);
   border-radius: 10px;
 

--- a/src/components/generic-card/GenericCard.module.css
+++ b/src/components/generic-card/GenericCard.module.css
@@ -10,7 +10,7 @@
     margin-bottom: 16px;
   }
 
-  & .buttons {
+  & .children {
     display: flex;
   }
 }

--- a/src/components/generic-card/GenericCard.module.css
+++ b/src/components/generic-card/GenericCard.module.css
@@ -1,0 +1,17 @@
+.genericCard {
+  padding: 58px;
+  border: 1px solid var(--gray-2);
+  border-radius: 10px;
+
+  & .title {
+    margin-bottom: 8px;
+  }
+
+  & .description {
+    margin-bottom: 16px;
+  }
+
+  & .buttons {
+    display: flex;
+  }
+}

--- a/src/components/generic-card/index.tsx
+++ b/src/components/generic-card/index.tsx
@@ -1,0 +1,22 @@
+import { H2, P } from "../text";
+import s from "./GenericCard.module.css";
+
+interface GenericCardProps {
+  title: string;
+  description: string;
+  children?: React.ReactNode;
+}
+
+export default function GenericCard({
+  title,
+  description,
+  children,
+}: GenericCardProps) {
+  return (
+    <div className={s.genericCard}>
+      <H2 className={s.title}>{title}</H2>
+      <P className={s.description}>{description}</P>
+      <div className={s.buttons}>{children}</div>
+    </div>
+  );
+}

--- a/src/components/generic-card/index.tsx
+++ b/src/components/generic-card/index.tsx
@@ -19,7 +19,7 @@ export default function GenericCard({
     <div className={s.genericCard} style={{ padding }}>
       <H2 className={s.title}>{title}</H2>
       <P className={s.description}>{description}</P>
-      {children ? null : <div className={s.children}>{children}</div>}
+      {children ? <div className={s.children}>{children}</div> : null}
     </div>
   );
 }

--- a/src/components/generic-card/index.tsx
+++ b/src/components/generic-card/index.tsx
@@ -1,19 +1,22 @@
+import { UnitProp } from "@/types/style";
 import { H2, P } from "../text";
 import s from "./GenericCard.module.css";
 
 interface GenericCardProps {
   title: string;
   description: string;
+  padding?: UnitProp;
   children?: React.ReactNode;
 }
 
 export default function GenericCard({
   title,
+  padding = "56px",
   description,
   children,
 }: GenericCardProps) {
   return (
-    <div className={s.genericCard}>
+    <div className={s.genericCard} style={{ padding }}>
       <H2 className={s.title}>{title}</H2>
       <P className={s.description}>{description}</P>
       <div className={s.buttons}>{children}</div>

--- a/src/components/generic-card/index.tsx
+++ b/src/components/generic-card/index.tsx
@@ -19,7 +19,7 @@ export default function GenericCard({
     <div className={s.genericCard} style={{ padding }}>
       <H2 className={s.title}>{title}</H2>
       <P className={s.description}>{description}</P>
-      <div className={s.buttons}>{children}</div>
+      {children ? null : <div className={s.children}>{children}</div>}
     </div>
   );
 }

--- a/src/components/generic-card/index.tsx
+++ b/src/components/generic-card/index.tsx
@@ -1,11 +1,11 @@
-import { UnitProp } from "@/types/style";
+import { SpacingProp } from "@/types/style";
 import { H2, P } from "../text";
 import s from "./GenericCard.module.css";
 
 interface GenericCardProps {
   title: string;
   description: string;
-  padding?: UnitProp;
+  padding?: SpacingProp;
   children?: React.ReactNode;
 }
 

--- a/src/components/grid-container/index.tsx
+++ b/src/components/grid-container/index.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import s from "./GridContainer.module.css";
+import { UnitProp } from "@/types/style";
 
 export const NavAndFooterGridConfig: GridConfig = {
   mobilePadding: "28px",
@@ -12,9 +13,6 @@ export const StandardGridConfig: GridConfig = {
   mobilePadding: "24px",
   maxWidth: "1300px",
 };
-
-type Unit = "px" | "em";
-type UnitProp = `${number}${Unit}`;
 
 interface GridContainerProps {
   className?: string;

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -3,7 +3,7 @@ import NavFooterLayout from "@/layouts/nav-footer-layout";
 import { loadDocsNavTreeData } from "@/lib/fetch-nav";
 import { DOCS_DIRECTORY } from "./docs/[...path]";
 import { NavTreeNode } from "@/components/nav-tree";
-import { H1, H2, P } from "@/components/text";
+import { H2, P } from "@/components/text";
 import Image from "next/image";
 
 export async function getStaticProps() {

--- a/src/pages/download/index.tsx
+++ b/src/pages/download/index.tsx
@@ -1,7 +1,7 @@
 import { ButtonLink } from "@/components/link";
 import { NavTreeNode } from "@/components/nav-tree";
 import SectionWrapper from "@/components/section-wrapper";
-import { H1, H2, P } from "@/components/text";
+import { H1 } from "@/components/text";
 import NavFooterLayout from "@/layouts/nav-footer-layout";
 import { fetchLatestGhosttyVersion } from "@/lib/fetch-latest-ghostty-version";
 import { loadDocsNavTreeData } from "@/lib/fetch-nav";
@@ -10,6 +10,7 @@ import Image from "next/image";
 import SVGIMG from "../../../public/ghostty-logo.svg";
 import { DOCS_DIRECTORY } from "../docs/[...path]";
 import s from "./DownloadPage.module.css";
+import GenericCard from "@/components/generic-card";
 
 export async function getStaticProps() {
   return {
@@ -45,7 +46,7 @@ export default function DownloadPage({
             <H1 className={s.pageTitle}>Download Ghostty</H1>
           </div>
           <div className={s.downloadCards}>
-            <DownloadCard
+            <GenericCard
               title="macOS"
               description="A universal binary that works on both Apple Silicon and Intel machines. Requires macOS 13+ (Ventura or later)."
             >
@@ -56,8 +57,8 @@ export default function DownloadPage({
                 icon={<Download strokeWidth={2} size={17} />}
                 showExternalIcon={false}
               />
-            </DownloadCard>
-            <DownloadCard
+            </GenericCard>
+            <GenericCard
               title="Linux"
               description="Choose a pre-built package for quick setup on your Linux distribution, or build source for complete control."
             >
@@ -77,26 +78,10 @@ export default function DownloadPage({
                   showExternalIcon={false}
                 />
               </div>
-            </DownloadCard>
+            </GenericCard>
           </div>
         </SectionWrapper>
       </main>
     </NavFooterLayout>
-  );
-}
-
-interface DownloadCardProps {
-  title: string;
-  description: string;
-  children?: React.ReactNode;
-}
-
-function DownloadCard({ title, description, children }: DownloadCardProps) {
-  return (
-    <div className={s.downloadCard}>
-      <H2 className={s.title}>{title}</H2>
-      <P className={s.description}>{description}</P>
-      <div className={s.buttons}>{children}</div>
-    </div>
   );
 }

--- a/src/pages/download/index.tsx
+++ b/src/pages/download/index.tsx
@@ -50,25 +50,22 @@ export default function DownloadPage({
               title="macOS"
               description="A universal binary that works on both Apple Silicon and Intel machines. Requires macOS 13+ (Ventura or later)."
             >
-
               <div className={s.macosLinks}>
-              <ButtonLink
-                size="large"
-                href={`https://release.files.ghostty.org/${latestVersion}/Ghostty.dmg`}
-                text="Universal Binary"
-                icon={<Download strokeWidth={2} size={17} />}
-                showExternalIcon={false}
-              />
-            </GenericCard>
-            <GenericCard
-              <ButtonLink
+                <ButtonLink
+                  size="large"
+                  href={`https://release.files.ghostty.org/${latestVersion}/Ghostty.dmg`}
+                  text="Universal Binary"
+                  icon={<Download strokeWidth={2} size={17} />}
+                  showExternalIcon={false}
+                />
+                <ButtonLink
                   size="large"
                   href="/docs/install/binary#macos"
                   text="Package Manager"
                   icon={<Package strokeWidth={2} size={18} />}
                   showExternalIcon={false}
                 />
-                </div>
+              </div>
             </GenericCard>
             <GenericCard
               title="Linux"

--- a/src/types/style.ts
+++ b/src/types/style.ts
@@ -1,3 +1,7 @@
 export type Unit = "px" | "em";
-export type UnitProp = `${number}${Unit}`;
-export type SpacingProp = 0 | UnitProp;
+export type UnitProp = `${number}${Unit}` | 0;
+export type SpacingProp =
+  | UnitProp
+  | `${UnitProp} ${UnitProp}`
+  | `${UnitProp} ${UnitProp} ${UnitProp}`
+  | `${UnitProp} ${UnitProp} ${UnitProp} ${UnitProp}`;

--- a/src/types/style.ts
+++ b/src/types/style.ts
@@ -1,0 +1,3 @@
+export type Unit = "px" | "em";
+export type UnitProp = `${number}${Unit}`;
+export type SpacingProp = 0 | UnitProp;


### PR DESCRIPTION
### What does this do?

hoists the `DownloadCard` component to it's own `GenericCard` component for future use. This component will probably be extended with the work on the Showcase page 

> [!NOTE]
> This is a recreation of #129 because GH did not like the transition from private > public repo 🥴 

#### Why?
To tackle #125, My plan is a "grid" of cards with an image, title and description (possibly a modal to open config etc). Instead of re-creating something, moving this card component made sense.

### Images/Video
#### Download page (unchanged as this is a component move but screenshotting for validity)
<img width="1596" alt="Screenshot 2024-12-26 at 19 25 07" src="https://github.com/user-attachments/assets/ff4157f3-c3c6-46e0-9a7e-614fc7f3fe7d" />


### Notes
- Closes #129
