### PR TITLE
fix: add info for brew installation for macos

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -25,7 +25,7 @@ process as installing many typical macOS applications.
 A Homebrew cask is available and maintained by the Ghostty community.
 
 ```bash
-brew install ghostty
+brew install --cask ghostty
 ```
 
 ## Linux

--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -22,7 +22,7 @@ process as installing many typical macOS applications.
 
 ### Homebrew
 
-A Homebrew cask is available and maintained by the Ghostty community.
+A [Homebrew cask](https://formulae.brew.sh/cask/ghostty) is available and maintained by the Ghostty community.
 
 ```bash
 brew install --cask ghostty


### PR DESCRIPTION
https://formulae.brew.sh/cask/ghostty#default

reverts #149 

the --cask is not needed per se, but specifies that ghostty is a cask, and not a regular package. i think it's best to keep consistency among formulae.brew.sh