### PR TITLE
add split panes info on quick terminal

### DIFF
--- a/docs/config/keybind/reference.mdx
+++ b/docs/config/keybind/reference.mdx
@@ -193,7 +193,7 @@ to bring it back up.
 The quick terminal has some limitations:
 
   - It is a singleton; only one instance can exist at a time.
-  - It does not support tabs.
+  - It does not support tabs. However, it does allow split panes with default keybindings.
   - It will not be restored when the application is restarted
     (for systems that support window restoration).
   - It supports fullscreen, but fullscreen will always be a non-native


### PR DESCRIPTION
Based on [#3518](https://github.com/ghostty-org/ghostty/issues/3518) I have added info regarding pane splitting in quick terminal. I hope this is ok. Please suggest any changes if required.
Thanks!