### PR TITLE
Improve syntax highlighting

### DIFF
--- a/docs/config/reference.mdx
+++ b/docs/config/reference.mdx
@@ -58,7 +58,7 @@ If you want to overwrite a previous set value rather than append a fallback,
 specify the value as `""` (empty string) to reset the list and then set the
 new values. For example:
 
-```
+```ini
 font-family = ""
 font-family = "My Favorite Font"
 ```

--- a/docs/help/terminfo.mdx
+++ b/docs/help/terminfo.mdx
@@ -55,7 +55,7 @@ everywhere, but in the meantime there are two ways to resolve the situation:
 The following one-liner will export the terminfo entry from your host and
 import it on the remote machine:
 
-```shell-session
+```sh
 infocmp -x | ssh YOUR-SERVER -- tic -x -
 ```
 

--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -24,7 +24,7 @@ process as installing many typical macOS applications.
 
 A [Homebrew cask](https://formulae.brew.sh/cask/ghostty) is available and maintained by the Ghostty community.
 
-```bash
+```sh
 brew install --cask ghostty
 ```
 

--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -37,7 +37,7 @@ need Xcode installed with both the macOS and iOS SDKs enabled. See
 With Zig and necessary dependencies installed, a binary can be built using
 `zig build`:
 
-```shell-session
+```sh
 zig build -Doptimize=ReleaseFast
 ```
 
@@ -67,25 +67,25 @@ Required dependencies:
 
 On Ubuntu and Debian, use:
 
-```
+```sh
 sudo apt install libgtk-4-dev libadwaita-1-dev git
 ```
 
 On Arch Linux, use
 
-```
+```sh
 sudo pacman -S gtk4 libadwaita
 ```
 
 On Fedora variants, use
 
-```
+```sh
 sudo dnf install gtk4-devel zig libadwaita-devel
 ```
 
 On Fedora Atomic variants, use
 
-```
+```sh
 rpm-ostree install gtk4-devel zig libadwaita-devel
 ```
 
@@ -149,7 +149,7 @@ After setting up the Nix environment, you can run the same `zig build`
 as on other distributions or you can also build the package with Nix
 by running:
 
-```shell-session
+```sh
 nix build .#ghostty
 ```
 
@@ -165,7 +165,7 @@ Xcode installed and the active developer directory pointing to it. If
 you're not sure that's the case, check the output of `xcode-select
 --print-path`:
 
-```shell-session
+```sh
 xcode-select --print-path
 /Library/Developer/CommandLineTools        # <-- BAD
 
@@ -181,7 +181,7 @@ Next, make sure you have both the macOS and iOS SDKs installed (from
 inside Xcode → Settings → Platforms). Finally, build Ghostty and the
 app:
 
-```shell-session
+```sh
 zig build -Doptimize=ReleaseFast
 cd macos && xcodebuild
 ```

--- a/src/lib/fetch-docs.ts
+++ b/src/lib/fetch-docs.ts
@@ -9,6 +9,7 @@ import { serialize } from "next-mdx-remote/serialize";
 import rehypeHighlight, {
   type Options as RehypeHighlightOptions,
 } from "rehype-highlight";
+import { all } from "lowlight";
 import remarkGfm from "remark-gfm";
 import slugify from "slugify";
 import type { Plugin } from "unified";
@@ -77,7 +78,13 @@ async function loadDocsPageFromRelativeFilePath(
           parseAnchorLinks({ pageHeaders }),
         ],
         rehypePlugins: [
-          [rehypeHighlight, { detect: true } satisfies RehypeHighlightOptions],
+          [
+            rehypeHighlight,
+            {
+              detect: false,
+              languages: all,
+            } satisfies RehypeHighlightOptions,
+          ],
         ],
       },
     },

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -68,7 +68,7 @@ body {
 }
 
 /* This a slightly modified atom-one-dark theme */
-.hljs {
+pre code {
   display: block;
   overflow-x: auto;
   padding: 0.5em;


### PR DESCRIPTION
Disables auto detection of the syntax highlighting language, which was causing some weird highlighting in cases where it wasn't detected correctly. This also corrects/adds missing language names to code blocks in the documentation itself, and sets the highlighter options to work for all languages (nix, for example, wasn't being highlighted).