### PR TITLE
Fix Arch installation instructions binary.mdx

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -62,6 +62,11 @@ branch from source is available in the Arch User Repository (AUR) as
 Installation may be done with an AUR helper or from source per the
 [usual AUR instructions](https://wiki.archlinux.org/title/Arch_User_Repository#Installing_and_upgrading_packages).
 
+```sh
+# Install Ghostty tip
+yay -S ghostty-git
+```
+
 <Note>
 This package is maintained by Arch Linux maintainers and not the Ghostty
 project.
@@ -119,11 +124,6 @@ Below is an example:
     };
   };
 }
-```
-
-```sh
-# Install Ghostty tip
-yay -S ghostty-git
 ```
 
 ### Void Linux


### PR DESCRIPTION
The instructions for arch got split incorrectly when the Gentoo and Nix instructions were added. This moves the AUR recipe back where it belongs.