### PR TITLE
add fedora install documentation

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -72,6 +72,19 @@ This package is maintained by Arch Linux maintainers and not the Ghostty
 project.
 </Note>
 
+### Fedora
+Ghostty is available in [Fedora COPR](https://copr.fedorainfracloud.org/coprs/pgdev/ghostty/).
+
+```sh
+dnf copr enable pgdev/ghostty 
+dnf install ghostty
+```
+
+<Note>
+This package is maintained by Fedora users and not the Ghostty project.
+</Note>
+
+
 ### Gentoo
 
 Ghostty is available in the official Gentoo repository.


### PR DESCRIPTION
adds install instructions from fedora copr 
https://copr.fedorainfracloud.org/coprs/pgdev/ghostty/