### PR TITLE
should execute `tic` with `sudo`

### DIFF
--- a/docs/help/terminfo.mdx
+++ b/docs/help/terminfo.mdx
@@ -56,7 +56,7 @@ The following one-liner will export the terminfo entry from your host and
 import it on the remote machine:
 
 ```sh
-infocmp -x | ssh YOUR-SERVER -- tic -x -
+infocmp -x | ssh YOUR-SERVER -- sudo tic -x -
 ```
 
 The `tic` command on the server may give the warning `"<stdin>", line 2,


### PR DESCRIPTION
If you ssh in without a root account (as is typical), you'll most likely need to run `tic` as `sudo tic` to get it to install the new terminfo