### PR TITLE
Fix broken favicon paths

### DIFF
--- a/src/layouts/root-layout/index.tsx
+++ b/src/layouts/root-layout/index.tsx
@@ -39,8 +39,8 @@ export default function RootLayout({
         <meta property="og:site_name" content="Ghostty" />
         <meta property="og:description" content={description} />
 
-        <link rel="icon" type="image/png" sizes="32x32" href="favicon-32.png" />
-        <link rel="icon" type="image/png" sizes="16x16" href="favicon-16.png" />
+        <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
+        <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
         <link rel="shortcut icon" href="/favicon.ico" />
         <meta property="og:image" content="/social-share-card.jpg" />
         <meta


### PR DESCRIPTION
Resolves #189 

Basically, favicon paths were not set properly in `src/layouts/root-layout/index.tsx`, causing the favicon to only appear properly at `/`