### PR TITLE
Added keybinding in docs/config/reference#quick-terminal-position

### DIFF
--- a/docs/config/reference.mdx
+++ b/docs/config/reference.mdx
@@ -1453,6 +1453,8 @@ Valid values are:
 
 Changing this configuration requires restarting Ghostty completely.
 
+By default there is no keybind to toggle quick terminal. Adding this to your config you can toggle quick terminal from anywhere: `keybind = global:alt+ctrl+s=toggle_quick_terminal`
+
 ## `quick-terminal-screen`
 
 The screen where the quick terminal should show up.


### PR DESCRIPTION
I was surfing through docs and found out that there is no default keybind set or how to set one for quick-terminal. By adding this to config keybind = `global:alt+ctrl+s=toggle_quick_terminal` will toggle quick terminal from anywhere in macos.