### PR TITLE
Add ability to sort sidecar

### DIFF
--- a/docs/config/keybind/reference.mdx
+++ b/docs/config/keybind/reference.mdx
@@ -2,6 +2,7 @@
 title: Keybinding Action Reference
 description: Reference of all Ghostty keybinding actions.
 editOnGithubLink: https://github.com/ghostty-org/ghostty/edit/main/src/input/Binding.zig
+alphabeticallySortedSidecar: true
 ---
 
 This is a reference of all Ghostty keybinding actions.

--- a/docs/config/reference.mdx
+++ b/docs/config/reference.mdx
@@ -2,6 +2,7 @@
 title: Reference
 description: Reference of all Ghostty configuration options.
 editOnGithubLink: https://github.com/ghostty-org/ghostty/edit/main/src/config/Config.zig
+alphabeticallySortedSidecar: true
 ---
 
 This is a reference of all Ghostty configuration options. These

--- a/src/components/sidecar/index.tsx
+++ b/src/components/sidecar/index.tsx
@@ -14,6 +14,7 @@ interface SidecarProps {
   className?: string;
   items: SidecarItem[];
   hidden?: boolean;
+  alphabeticallySorted?: boolean;
 }
 
 // If there's less items than this, the sidecar content won't render
@@ -27,6 +28,7 @@ export default function Sidecar({
   className,
   items,
   hidden = false,
+  alphabeticallySorted = false,
 }: SidecarProps) {
   const activeItemRef = useRef<HTMLLIElement>(null);
   const sidecarRef = useRef<HTMLDivElement>(null);
@@ -37,6 +39,12 @@ export default function Sidecar({
   const activeHeaderID = useMemo(() => {
     return shownItems.find((v) => headerIdsInView.includes(v.id))?.id;
   }, [shownItems, headerIdsInView]);
+  const sortedItems = useMemo(() => {
+    if (alphabeticallySorted) {
+      return items.sort((a, b) => a.title.localeCompare(b.title));
+    }
+    return items;
+  }, [items, alphabeticallySorted]);
 
   useEffect(() => {
     if (activeItemRef.current && sidecarRef.current) {
@@ -55,9 +63,9 @@ export default function Sidecar({
 
   return (
     <div ref={sidecarRef} className={classNames(s.sidecar, className)}>
-      {items.length > MIN_SIDECAR_ITEMS && !hidden && (
+      {sortedItems.length > MIN_SIDECAR_ITEMS && !hidden && (
         <ul>
-          {items.map(({ id, title, depth }) => {
+          {sortedItems.map(({ id, title, depth }) => {
             const active = id === activeHeaderID;
             return (
               <li

--- a/src/lib/fetch-docs.ts
+++ b/src/lib/fetch-docs.ts
@@ -38,6 +38,7 @@ export interface DocsPageData {
   content: MDXRemoteSerializeResult;
   relativeFilePath: string;
   pageHeaders: PageHeader[];
+  alphabeticallySortedSidecar: boolean;
 }
 
 export async function loadDocsPage(
@@ -104,6 +105,9 @@ async function loadDocsPageFromRelativeFilePath(
       : null,
     hideSidecar: mdxFileContent.data.hasOwnProperty("hideSidecar")
       ? mdxFileContent.data.hideSidecar
+      : false,
+    alphabeticallySortedSidecar: mdxFileContent.data.hasOwnProperty("alphabeticallySortedSidecar")
+      ? mdxFileContent.data.alphabeticallySortedSidecar
       : false,
     content,
     pageHeaders,

--- a/src/pages/docs/[...path]/index.tsx
+++ b/src/pages/docs/[...path]/index.tsx
@@ -77,6 +77,7 @@ export default function DocsPage({
     relativeFilePath,
     pageHeaders,
     hideSidecar,
+    alphabeticallySortedSidecar,
   },
   breadcrumbs,
 }: DocsPageProps) {
@@ -143,6 +144,7 @@ export default function DocsPage({
             hidden={hideSidecar}
             className={s.sidecar}
             items={pageHeaders}
+            alphabeticallySorted={alphabeticallySortedSidecar}
           />
         </main>
       </div>


### PR DESCRIPTION
I initially started a discussion here https://github.com/ghostty-org/ghostty/discussions/3397 , however seeing this feature might help with other issues like https://github.com/ghostty-org/website/issues/155 , I figured I'ld open a PR directly.

This PR adds the ability to alphabetically sort the sidecar on any given view one wants.

This helps me a lot when I am looking for configuration options and I know almost what it's named, or what I believe it should be named.

I also see that this is wanted on the keybinding page.

I opted _not_ to sort the content of these pages, because I do find it useful to be able to show the most common requested config first, regardless of whether this is will be first in a sorted list.

Before (sidecar unsorted):
<img width="1643" alt="image" src="https://github.com/user-attachments/assets/df9bd5b3-a2ed-45b0-ab3f-1952e206d2ca" />
After (sidecar sorted):
<img width="1643" alt="image" src="https://github.com/user-attachments/assets/4c11af88-4870-4c77-9461-9458ea1e7ddb" />