### PR TITLE
docs(binary): fix typo

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -64,7 +64,7 @@ Installation may be done with an AUR helper or from source per the
 [usual AUR instructions](https://wiki.archlinux.org/title/Arch_User_Repository#Installing_and_upgrading_packages).
 
 ```sh
-# Install Ghostty tip
+# Install Ghostty git
 yay -S ghostty-git
 ```
 


### PR DESCRIPTION
The `ghostty-git` install command contains a comment about installing `Ghostty tip`. I assume this is a typo and should be `Ghostty git`. However, none of the other installation methods have such a comment, so it might be better to remove it all together.