### PR TITLE
Add: Terra repo for Fedora

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -151,6 +151,7 @@ Ghostty is also available in [Terra](https://terra.fyralabs.com/).
 
 ```sh
 dnf install --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' terra-release
+dnf install ghostty
 ```
 
 <Warning>

--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -147,6 +147,12 @@ dnf copr enable pgdev/ghostty
 dnf install ghostty
 ```
 
+Ghostty is also available in [Terra](https://terra.fyralabs.com/).
+
+```sh
+dnf install --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' terra-release
+```
+
 <Warning>
-This is a user-maintained package and not an official Fedora package.
+These are user-maintained packages and not an official Fedora package.
 </Warning>


### PR DESCRIPTION
Ghostty is now available as a package in Terra.