### PR TITLE
Change binary.mdx Fedora section to use sudo in install command

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -143,8 +143,8 @@ of caution should be taken when installing them.
 Ghostty is available in [Fedora COPR](https://copr.fedorainfracloud.org/coprs/pgdev/ghostty/).
 
 ```sh
-dnf copr enable pgdev/ghostty
-dnf install ghostty
+sudo dnf copr enable pgdev/ghostty
+sudo dnf install ghostty
 ```
 
 <Warning>


### PR DESCRIPTION
You're not supposed to use sudo on Linux in most cases but let's be real, everyone does and this just makes the install process slightly more smooth.