### PR TITLE
Add 'aria-hidden={true}' to <section> at /

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -76,7 +76,7 @@ export default function Home({ terminalData }: HomePageProps) {
           of the terminal to the true calculated size */}
         {windowWidth > 0 && (
           <>
-            <section className={s.terminalWrapper}>
+            <section className={s.terminalWrapper} aria-hidden={true}>
               <AnimatedTerminal
                 title={"👻 Ghostty"}
                 fontSize={fontSize}


### PR DESCRIPTION
Adds `aria-hidden={true}` to the `<section>` in `src/pages/index.tsx` to prevent screen readers from reading the content of the animated terminal out loud.