### PR TITLE
Misc Website Polish

### DIFF
--- a/src/components/animated-terminal/index.tsx
+++ b/src/components/animated-terminal/index.tsx
@@ -14,8 +14,7 @@ class AnimationManager {
     this.frameTime = 1000 / fps;
   }
 
-  updateSettings(callback: () => void, fps: number = 30) {
-    this.callback = callback;
+  updateFPS(fps: number) {
     this.frameTime = 1000 / fps;
   }
 
@@ -46,6 +45,19 @@ class AnimationManager {
     this._animation = requestAnimationFrame(this.update);
   };
 }
+
+const KONAMI_CODE = [
+  "arrowup",
+  "arrowup",
+  "arrowdown",
+  "arrowdown",
+  "arrowleft",
+  "arrowright",
+  "arrowleft",
+  "arrowright",
+  "b",
+  "a",
+];
 
 export type AnimationFrame = string[];
 
@@ -81,8 +93,27 @@ export default function AnimatedTerminal({
 
     const handleFocus = () => animationManager.start();
     const handleBlur = () => animationManager.pause();
+    const codeInProgress: string[] = [];
+    const handleKeyUp = (event: KeyboardEvent) => {
+      const key = event.key.toLowerCase();
+      if (KONAMI_CODE[codeInProgress.length] === key) {
+        codeInProgress.push(key);
+      } else {
+        codeInProgress.length = 0;
+      }
+      if (codeInProgress.length !== KONAMI_CODE.length) {
+        return;
+      }
+      if (animationManager.frameTime === 1000 / 30) {
+        animationManager.updateFPS(240);
+      } else {
+        animationManager.updateFPS(30);
+      }
+      codeInProgress.length = 0;
+    };
     window.addEventListener("focus", handleFocus);
     window.addEventListener("blur", handleBlur);
+    window.addEventListener("keyup", handleKeyUp);
 
     if (document.hasFocus()) {
       animationManager.start();
@@ -90,6 +121,7 @@ export default function AnimatedTerminal({
     return () => {
       window.removeEventListener("focus", handleFocus);
       window.removeEventListener("blur", handleBlur);
+      window.removeEventListener("keyup", handleKeyUp);
     };
   }, [animationManager, frames.length]);
 

--- a/src/components/terminal/Terminal.module.css
+++ b/src/components/terminal/Terminal.module.css
@@ -57,7 +57,7 @@
     align-items: center;
     position: relative;
     border-radius: 9px 9px 0px 0px;
-    padding: var(--padding);
+    padding: var(--padding) 11px;
 
     grid-template: "controls title .";
     grid-template-columns: 1fr 1fr 1fr;

--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -1,5 +1,12 @@
 .homePage {
   padding: 32px 0;
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
 
   & .terminalWrapper {
     margin-bottom: 20px;


### PR DESCRIPTION
Was poking around a bit on the code for the Ghostty website and came up with a few items that I figured I could improve/clean up.

Probably easiest to look at the commits in order, but I'll list out the changes here.

**1. macOS Traffic Light Fixes**

Noticed a bit of a horizontal vs vertical padding imbalance with the macOS traffic light icons, so made a small tweak there

| BEFORE | AFTER |
| - | - |
| ![CleanShot 2024-12-29 at 23 29 25](https://github.com/user-attachments/assets/e00ed58f-8210-4e64-9419-06ff2c1ec4b0) | ![CleanShot 2024-12-29 at 23 29 08](https://github.com/user-attachments/assets/2426059d-6707-4612-9193-538616c2f28c) |

**2. Refactored Animation Loop Code**

Before the code was using setInterval which doesn't necessarily sync well with your monitor's screen updates. `requestAnimationFrame` is the more idealized API for such actions, but they require a bit more book keeping. So I created a little animation manager class that allows the animation to be controlled through `requestAnimationFrame`. I also took this time to pull pause/resume out of the react lifecycle.

**3. Vertically Center Homepage Content**

Mostly just something that I think fits better with the current minimal homepage

![CleanShot 2024-12-29 at 23 34 45](https://github.com/user-attachments/assets/4554b5a1-00dc-4aae-8bc7-8c6cde20ca4f)
