### PR TITLE
Add build deps for Gentoo

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -94,6 +94,11 @@ On Fedora Atomic variants, use
 rpm-ostree install gtk4-devel zig libadwaita-devel
 ```
 
+On Gentoo, use
+```sh
+emerge -av libadwaita gtk
+```
+
 On Solus, use
 
 ```sh


### PR DESCRIPTION
Adds build dependencies for Gentoo at [/docs/install/build](https://ghostty.org/docs/install/build)
![image](https://github.com/user-attachments/assets/3e37c7b1-cb57-454a-b44f-b6e7489de08b)
