### PR TITLE
Add 'git clone ...' to build instructions

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -34,9 +34,14 @@ On Linux, you may need to install additional dependencies. See
 need Xcode installed with both the macOS and iOS SDKs enabled. See
 [Mac `.app`](#mac-.app).
 
-With Zig and necessary dependencies installed, a binary can be built using
-`zig build`:
+With Zig and necessary dependencies installed, first clone and enter the local repository.
+```sh
+git clone https://github.com/ghostty-org/ghostty
+cd ghostty
+```
 
+Then, a binary can be built using
+`zig build`:
 ```sh
 zig build -Doptimize=ReleaseFast
 ```


### PR DESCRIPTION
There was some confusion in the Discord on the steps needed to build from source, so I added the git instructions to the Build from Source page to resolve that.

![image](https://github.com/user-attachments/assets/26560b0e-c0c7-4cdc-bdbc-0ddf8730ee6b)
