### PR TITLE
Update shell-integration.mdx

### DIFF
--- a/docs/features/shell-integration.mdx
+++ b/docs/features/shell-integration.mdx
@@ -131,7 +131,7 @@ Each shell integration's installation instructions are documented inline:
 | Shell    | Integration                                                                                    |
 | -------- | ---------------------------------------------------------------------------------------------- |
 | `bash`   | `${GHOSTTY_RESOURCES_DIR}/shell-integration/bash/ghostty.bash`                                 |
-| `fish`   | `${GHOSTTY_RESOURCES_DIR}/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish` |
+| `fish`   | `"$GHOSTTY_RESOURCES_DIR"/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish` |
 | `zsh`    | `${GHOSTTY_RESOURCES_DIR}/shell-integration/zsh/ghostty-integration`                           |
 | `elvish` | `${GHOSTTY_RESOURCES_DIR}/shell-integration/elvish/lib/ghostty-integration.elv`                |
 


### PR DESCRIPTION
Fish shell doesn't use curly brackets for substituting variables in strings. The affected line is specifically targeted at fish shell so I figured it should use what you actually need to paste