### PR TITLE
Fix: No highlighted sidecar items when scrolling through long articles

### DIFF
--- a/src/components/sidecar/index.tsx
+++ b/src/components/sidecar/index.tsx
@@ -34,9 +34,19 @@ export default function Sidecar({
   const shownItems = useMemo(() => {
     return items.filter((v) => v.depth <= MAX_SIDECAR_HEADER_DEPTH);
   }, [items]);
+  const [lastActiveHeaderID, setLastActiveHeaderID] = useState<string | null>(
+    null,
+  );
   const activeHeaderID = useMemo(() => {
-    return shownItems.find((v) => headerIdsInView.includes(v.id))?.id;
-  }, [shownItems, headerIdsInView]);
+    const currentActiveID = shownItems.find((v) =>
+      headerIdsInView.includes(v.id),
+    )?.id;
+    if (currentActiveID && currentActiveID !== lastActiveHeaderID) {
+      setLastActiveHeaderID(currentActiveID);
+      return currentActiveID;
+    }
+    return lastActiveHeaderID;
+  }, [shownItems, headerIdsInView, lastActiveHeaderID]);
 
   useEffect(() => {
     if (activeItemRef.current && sidecarRef.current) {


### PR DESCRIPTION
Bit of a pet peeve issue here, but when scrolling through longer sections, the sidecar will sometimes lose focus on what article is currently active.

[Screencast_20241230_102045.webm](https://github.com/user-attachments/assets/5f2d3d6c-b84c-4c32-bf44-5a599cf9a498)

This should keep at least *something* focused, which makes quickly scrolling through the docs less disorienting.

[Screencast_20241230_102155.webm](https://github.com/user-attachments/assets/bf563de3-e14c-49c2-802e-10373d36d0b8)
