### PR TITLE
note: Mention gcc-multilib as possible dependency

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -70,17 +70,32 @@ Required dependencies:
   * `libadwaita`
   * `pkg-config`
 
-On Ubuntu and Debian, use:
+#### Arch Linux
+
+```sh
+sudo pacman -S gtk4 libadwaita
+```
+
+#### Debian and Ubuntu
 
 ```sh
 sudo apt install libgtk-4-dev libadwaita-1-dev git
 ```
 
-On Arch Linux, use
+On Debian unstable/testing, the `gcc-multilib` package is also required
+for building.
 
-```sh
-sudo pacman -S gtk4 libadwaita
-```
+<Note>
+**A recent GTK is required for Ghostty to work with Nvidia (GL) drivers
+under x11.** Ubuntu 22.04 LTS has GTK 4.6 which is not new enough. Ubuntu 23.10
+has GTK 4.12 and works. From [this discussion](https://discourse.gnome.org/t/opengl-context-version-not-respected-on-gtk4-rs/12162?u=cdehais)
+the problem was fixed in GTK by Dec 2022. Also, if you are a BTRFS user, make
+sure to manually upgrade your Kernel (6.6.6 will work). The stock kernel in
+Ubuntu 23.10 is 6.5.0 which has a bug which
+[causes zig to fail its hash check for packages](https://github.com/ziglang/zig/issues/17282).
+</Note>
+
+#### Fedora
 
 On Fedora variants, use
 
@@ -94,32 +109,23 @@ On Fedora Atomic variants, use
 rpm-ostree install gtk4-devel zig libadwaita-devel
 ```
 
-On Gentoo, use
+#### Gentoo
+
 ```sh
 emerge -av libadwaita gtk
 ```
 
-On Solus, use
-
-```sh
-sudo eopkg install libgtk-4-devel libadwaita-devel perl-extutils-pkgconfig
-```
-
-On OpenSuse Tumbleweed, use
+#### openSUSE Tumbleweed
 
 ```sh
 sudo zypper install gtk4-tools libadwaita-devel pkgconf-pkg-config zig
 ```
 
-<Note>
-**A recent GTK is required for Ghostty to work with Nvidia (GL) drivers
-under x11.** Ubuntu 22.04 LTS has GTK 4.6 which is not new enough. Ubuntu 23.10
-has GTK 4.12 and works. From [this discussion](https://discourse.gnome.org/t/opengl-context-version-not-respected-on-gtk4-rs/12162?u=cdehais)
-the problem was fixed in GTK by Dec 2022. Also, if you are a BTRFS user, make
-sure to manually upgrade your Kernel (6.6.6 will work). The stock kernel in
-Ubuntu 23.10 is 6.5.0 which has a bug which
-[causes zig to fail its hash check for packages](https://github.com/ziglang/zig/issues/17282).
-</Note>
+#### Solus
+
+```sh
+sudo eopkg install libgtk-4-devel libadwaita-devel perl-extutils-pkgconfig
+```
 
 <Warning>
 GTK 4.14 on Wayland has a bug which may cause an immediate crash.


### PR DESCRIPTION
On development Debian based distros the listed  dependencies does not meet the building requirements. In notes we mention  `gcc-multilib` which might not installed (not part of build-essential metapackage, nor required/recommended for libadwaita/libgtk).

E.g.: ghostty build successfully on Debian Bookworm, but not on Debian Testing without gcc-multilib