### PR TITLE
Add a Link to .deb for Ubuntu

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -184,3 +184,19 @@ After adding the repository, install Ghostty:
 ```sh
 rpm-ostree update --install ghostty
 ```
+
+### Ubuntu
+
+An Ubuntu package (.deb) is available from
+[ghostty-ubuntu](https://github.com/mkasberg/ghostty-ubuntu) on GitHub. After
+downloading the .deb for your Ubuntu version from the
+[Releases](https://github.com/mkasberg/ghostty-ubuntu/releases) page, install it
+as below:
+
+```sh
+sudo dpkg -i ghostty_*.deb
+```
+
+<Warning>
+This is a user-maintained package. It is not an official Ubuntu package.
+</Warning>


### PR DESCRIPTION
https://github.com/mkasberg/ghostty-ubuntu

Ubuntu is still one of the most popular Linux distributions, and I want to make it easier for everyone to install Ghostty on Ubuntu. Getting official Ubuntu packages (perhaps even PPAs) will take some time because Ubuntu still does not have official zig packages. But we can build a .deb on GitHub Actions and make it available to download on GitHub. That's the approach I'm taking in the above repo, which will hopefully be a good interim solution. (All of the usual caveats about unofficial packages still apply.)