### PR TITLE
Bug Fix: Fix aria-hidden error

### DIFF
--- a/src/components/terminal/Terminal.module.css
+++ b/src/components/terminal/Terminal.module.css
@@ -141,7 +141,7 @@
       }
     }
 
-    &:hover .header {
+    & .header {
       background: var(--adw-headerbar-color);
     }
   }
@@ -153,7 +153,7 @@
       gap: 8px;
     }
 
-    &:hover .windowControls {
+    & .windowControls {
       & li:first-child {
         background: var(--color-sunset-orange);
       }

--- a/src/components/terminal/index.tsx
+++ b/src/components/terminal/index.tsx
@@ -38,7 +38,7 @@ export default function Terminal({
   const handleScroll = (e: UIEvent<HTMLElement>) => {
     const { scrollTop, scrollHeight, clientHeight } = e.target as HTMLElement;
     const position = Math.ceil(
-      (scrollTop / (scrollHeight - clientHeight)) * 100
+      (scrollTop / (scrollHeight - clientHeight)) * 100,
     );
     if (position < 100) {
       setAutoScroll(false);
@@ -61,7 +61,6 @@ export default function Terminal({
   const padding = " ".repeat(whitespacePadding);
   return (
     <div
-      tabIndex={0}
       className={classNames(
         s.terminal,
         className,
@@ -75,7 +74,7 @@ export default function Terminal({
         {
           [s.adwaita]: platformStyle === "adwaita",
           [s.macos]: platformStyle === "macos",
-        }
+        },
       )}
       style={
         {


### PR DESCRIPTION
When the fix was applied for screen readers we triggered an error because the container of the terminal interface had a tab index, which it really shouldn't since there's nothing to interact with.

I've removed this tab index and also made the quick change to force the various header bar states to not have a toggle on hover since 1. it's a bit distracting and 2. sort of unnecessary.

This is what the error looked like:

![CleanShot 2024-12-31 at 15 07 43](https://github.com/user-attachments/assets/19f84773-5e8b-43e9-87f0-56aac97b8887)

This also has the nice side effect as a single tab action takes us directly to the download button.

Also it looks like there were some prettier changes that tweaked parts of the file.