### PR TITLE
Fix URL typo in GNOME GitLab link in build.mdx

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -130,7 +130,7 @@ sudo eopkg install libgtk-4-devel libadwaita-devel perl-extutils-pkgconfig
 <Warning>
 GTK 4.14 on Wayland has a bug which may cause an immediate crash.
 There is an
-[open issue](https://gitlab.gnome.org/GNOME/gtk/-/issues/6589/note_2072039)
+[open issue](https://gitlab.gnome.org/GNOME/gtk/-/issues/6589)
 to track this GTK bug. You can workaround this issue by running ghostty with
 `GDK_DEBUG=gl-disable-gles ghostty`.
 </Warning>


### PR DESCRIPTION
The current URL redirects to the GNOME GitLab login page. Not sure what the intention was, was it https://gitlab.gnome.org/GNOME/gtk/-/issues/6589#note_2072039 or https://gitlab.gnome.org/GNOME/gtk/-/issues/6589?