### PR TITLE
Update openSUSE repository path

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -200,7 +200,7 @@ rpm-ostree update --install ghostty
 Ghostty is available for openSUSE Tumbleweed:
 
 ```sh
-zypper addrepo https://download.opensuse.org/repositories/home:avindra/openSUSE_Tumbleweed/home:avindra.repo
+zypper addrepo https://download.opensuse.org/repositories/X11:/terminals/openSUSE_Factory/X11:terminals.repo
 zypper refresh
 zypper install ghostty
 ```


### PR DESCRIPTION
As seen in [OBS]( https://build.opensuse.org/request/show/1233711) the package from home:avindra was submitted to X11:terminals and therefore the repository path needs to be updated.