### PR TITLE
docs(config/reference): fix typos

### DIFF
--- a/docs/config/reference.mdx
+++ b/docs/config/reference.mdx
@@ -569,7 +569,7 @@ Multiplier for scrolling distance with the mouse wheel. Any value less
 than 0.01 or greater than 10,000 will be clamped to the nearest valid
 value.
 
-A value of "1" (default) scrolls te default amount. A value of "2" scrolls
+A value of "1" (default) scrolls the default amount. A value of "2" scrolls
 double the default amount. A value of "0.5" scrolls half the default amount.
 Et cetera.
 
@@ -758,7 +758,7 @@ default value of the running program.
 This configuration can be reloaded at runtime. If it is set, the title
 will update for all windows. If it is unset, the next title change escape
 sequence will be honored but previous changes will not retroactively
-be set. This latter case may require you restart programs such as neovim
+be set. This latter case may require you to restart programs such as Neovim
 to get the new title.
 
 ## `class`


### PR DESCRIPTION
Fixes:
- te -> the
- require you restart -> require you to restart
- neovim -> Neovim