### PR TITLE
Add information on split direction values

### DIFF
--- a/docs/config/keybind/reference.mdx
+++ b/docs/config/keybind/reference.mdx
@@ -124,8 +124,20 @@ This only works with libadwaita enabled currently.
 Create a new split in the given direction. The new split will appear in
 the direction given.
 
+Valid values are:
+* `left`
+* `right`
+* `down`
+* `up`
+
 ## `goto_split`
 Focus on a split in a given direction.
+
+Valid values are:
+* `left`
+* `right`
+* `top`
+* `bottom`
 
 ## `toggle_split_zoom`
 zoom/unzoom the current split.


### PR DESCRIPTION
I experienced some minor confusion while making Ghosty splits behave more like Emacs. Example values I ended up with:
```
keybind = ctrl+x>2=new_split:right
keybind = ctrl+x>3=new_split:down
keybind = super+left=goto_split:left
keybind = super+right=goto_split:right
keybind = super+up=goto_split:top
keybind = super+down=goto_split:bottom
```

The confusion arose from `new_split` using up/down while `goto_split` uses top/bottom. Felt like the docs could benefit from having some example values to avoid this confusion 🙂 


Installed via homebrew on an m1 mac today, so should be the latest version. Feel free to reject this PR if not relevant anymore (or if I'm stupid) 🙂 