### PR TITLE
Link to Release Notes from Download Page

### DIFF
--- a/src/pages/download/DownloadPage.module.css
+++ b/src/pages/download/DownloadPage.module.css
@@ -20,6 +20,10 @@
         font-size: 38px;
         margin-bottom: 48px;
       }
+
+      & > div {
+        font-size: 16px;
+      }
     }
   }
 

--- a/src/pages/download/index.tsx
+++ b/src/pages/download/index.tsx
@@ -43,7 +43,10 @@ export default function DownloadPage({
         <SectionWrapper>
           <div className={s.header}>
             <Image src={SVGIMG} alt={""} />
-            <H1 className={s.pageTitle}>Download Ghostty</H1>
+            <div className={s.pageTitle}>
+              <H1>Download Ghostty</H1>
+              <div><b>{ latestVersion }</b> (<a href={ "/docs/install/release-notes/" + latestVersion.replace(/\./g, "-") }>Release Notes</a>)</div>
+            </div>
           </div>
           <div className={s.downloadCards}>
             <GenericCard


### PR DESCRIPTION
We want to show the latest version and link to release notes from the download page.

I took a pretty straight-forward and minimal approach; happy to iterate on that if there's any design feedback. I though of putting it closer to the download links but couldn't figure out a way to do so without duplicating it on each card (which might not be too bad anyway)...

![image](https://github.com/user-attachments/assets/a891930d-4609-4a26-885e-2a852d012132)

Fixes #242