### PR TITLE
Clarify OSX<sonoma instructions

### DIFF
--- a/docs/help/terminfo.mdx
+++ b/docs/help/terminfo.mdx
@@ -74,8 +74,9 @@ field as an alias` which can be safely ignored.
 The bundled version of `ncurses` is too old to emit a terminfo entry that can be
 read by more recent versions of `tic`, and the command will fail with a bunch
 of `Illegal character` messages. You can fix this by using Homebrew to install
-a recent version of `ncurses` and replacing `infocmp` above with the full path
-`/opt/homebrew/opt/ncurses/bin/infocmp`.
+a recent version of `ncurses` with `brew install ncurses` and replacing 
+`infocmp` above with the full path `/opt/homebrew/opt/ncurses/bin/infocmp` or 
+`/usr/local/opt/ncurses/bin/infocmp`.
 </Note>
 
 ### Configure SSH to fall back to a known terminfo entry


### PR DESCRIPTION
The brew prefix folder can be different, in my case:

```
❯ brew config
HOMEBREW_VERSION: 4.4.14
ORIGIN: https://github.com/Homebrew/brew
HEAD: f84082963da8af8c9ccd6dffbe932eba457e2b78
Last commit: 4 days ago
Branch: stable
Core tap JSON: 03 Jan 21:11 UTC
Core cask tap JSON: 03 Jan 21:11 UTC
HOMEBREW_PREFIX: /usr/local
...
```

```
❯ ls -l /usr/local/opt/ncurses/bin/infocmp
-r-xr-xr-x@ 1 edu  admin  86616 Jan  3 22:12 /usr/local/opt/ncurses/bin/infocmp

~
❯ ls -l /opt/
total 0
``` 