### PR TITLE
Rephrase support for rendering RTL scripts

### DIFF
--- a/docs/features/index.mdx
+++ b/docs/features/index.mdx
@@ -48,8 +48,9 @@ features that Ghostty supports:
 
 - **Grapheme clustering**: Multi-codepoint emoji such as flags,
   skin tones, etc. are rendered correctly as a single character.
-  Certain languages like Arabic and Hebrew are also rendered
-  correctly (LTR only).
+  Individual grapheme clusters in certain right-to-left scripts
+  like Arabic and Hebrew are also rendered correctly, although
+  only left-to-right text is supported.
 
 - **Kitty graphics protocol**: Ghostty supports the Kitty graphics
   protocol, which allows terminal applications to render images


### PR DESCRIPTION
As discussed in https://github.com/ghostty-org/ghostty/issues/1442#issuecomment-2565793137,
this clarifies that RTL text is not supported, although rendering of
individual grapheme clusters from RTL scripts is done correctly.

cc @Flimm - is this language clearer?