### PR TITLE
package wayland-protocols-devel needed on CentOS Stream 9

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -107,13 +107,13 @@ Ubuntu 23.10 is 6.5.0 which has a bug which
 On Fedora variants, use
 
 ```sh
-sudo dnf install gtk4-devel zig libadwaita-devel
+sudo dnf install gtk4-devel zig libadwaita-devel wayland-protocols-devel
 ```
 
 On Fedora Atomic variants, use
 
 ```sh
-rpm-ostree install gtk4-devel zig libadwaita-devel
+rpm-ostree install gtk4-devel zig libadwaita-devel wayland-protocols-devel
 ```
 
 #### Gentoo


### PR DESCRIPTION
Package `wayland-protocols-devel` needs to be installed for the latest code to build, otherwise FTBFS.

Running the following fixes the build:

```
dnf install wayland-protocols-devel.noarch
```

NOTE: I haven't tested the Fedora Atomic package names.