### PR TITLE
Fix incorrect Xcode platforms settings path

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -229,7 +229,7 @@ The above can happen if you install the Xcode Command Line Tools _after_ Xcode
 is installed.
 
 Next, make sure you have both the macOS and iOS SDKs installed (from
-inside Xcode → Settings → Platforms). Finally, build Ghostty and the
+inside Xcode → Settings → Components). Finally, build Ghostty and the
 app:
 
 ```sh


### PR DESCRIPTION
Typo fix in the Mac `.app` installation section