### PR TITLE
Add link for Universal AppImage Distribution

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -232,3 +232,25 @@ sudo dpkg -i ghostty_*.deb
 <Warning>
 This is a user-maintained package. It is not an official Ubuntu package.
 </Warning>
+
+### Universal AppImage
+
+Ghosty is available as a Universal AppImage from
+[ghostty-appimage](https://github.com/psadi/ghostty-appimage) on GitHub.
+Upon downloading the `.appimage` file from the
+[Releases](https://github.com/psadi/ghostty-appimage/releases) page, follow the
+below instructions:
+
+```bash
+chmod +x Ghostty-x86_64.AppImage
+./Ghostty-x86_64.AppImage
+```
+
+Alternatively, setup can be done graphically by right-clicking
+the `Ghostty-x86_64.AppImage` file, selecting **Properties**, navigating to
+the **Permissions** tab and checking the box that says **Executable as
+Program**.
+
+<Warning>
+This is a user-maintained AppImage. It is not an official AppImage.
+</Warning>


### PR DESCRIPTION
Bundling Ghostty Terminal as a Universal AppImage, This will allow users to easily run Ghostty on various Linux distributions without the hassle of managing dependencies. Fixes [#4824](https://github.com/ghostty-org/ghostty/discussions/4824)

Repository Link: [Ghostty AppImage Repository](https://github.com/psadi/ghostty-appimage)

Benefits of the AppImage:

1. Universal Compatibility: Works on various Linux distributions.
1. No Installation Required: Just download and run!
1. Self-Contained: Includes all necessary dependencies.

Next is to publish the appimage to [AppImageHub](https://appimage.github.io/)

~~add support for other architectures (ARM etc)~~.

Edit: Arm/aarch64 appimage builds are now available. 