### PR TITLE
Include "Error: opening terminal" for findability

### DIFF
--- a/docs/help/terminfo.mdx
+++ b/docs/help/terminfo.mdx
@@ -48,7 +48,8 @@ this for you. To enable the shell-integration feature specify
 
 If you use SSH to connect to other machines that do not have Ghostty's
 terminfo entry, you will see error messages like `missing or unsuitable
-terminal: xterm-ghostty` or `WARNING: terminal is not fully functional`.
+terminal: xterm-ghostty`, `Error opening terminal: xterm-ghostty.` or 
+`WARNING: terminal is not fully functional`.
 
 Hopefully someday Ghostty will have terminfo entries pre-distributed
 everywhere, but in the meantime there are two ways to resolve the situation:


### PR DESCRIPTION
I only found the terminfo FAQ section by going via GH Issue comments... I think just adding this error string is helpful; it is by far the most common error I have been seeing while testing.