### PR TITLE
Fix typo - mouse-scroll-multiplier

### DIFF
--- a/docs/config/reference.mdx
+++ b/docs/config/reference.mdx
@@ -573,7 +573,7 @@ Multiplier for scrolling distance with the mouse wheel. Any value less
 than 0.01 or greater than 10,000 will be clamped to the nearest valid
 value.
 
-A value of "1" (default) scrolls te default amount. A value of "2" scrolls
+A value of "1" (default) scrolls the default amount. A value of "2" scrolls
 double the default amount. A value of "0.5" scrolls half the default amount.
 Et cetera.
 


### PR DESCRIPTION
This PR is just to fix a typo of "te" -> "the" in the "mouse-scroll-multiplier" reference.