### PR TITLE
Fixed presumed typos in theme.mdx

### DIFF
--- a/docs/features/theme.mdx
+++ b/docs/features/theme.mdx
@@ -115,9 +115,10 @@ palette = 12=#7b9ef0
 palette = 13=#f2a4db
 palette = 14=#5abfb5
 palette = 15=#b5bfe2
-background = 303446
-foreground = c6d0f5
-cursor-color = f2d5cf
-selection-background = 626880
-selection-foreground = c6d0f5
+background = #303446
+foreground = #c6d0f5
+cursor-color = #f2d5cf
+cursor-text = #c6d0f5
+selection-background = #626880
+selection-foreground = #c6d0f5
 ```


### PR DESCRIPTION
`theme.mdx` presumably has missing hashtags in the front of hexadecimal codes. It was also missing the `cursor-text` option.