### PR TITLE
Update terminfo.mdx

### DIFF
--- a/docs/help/terminfo.mdx
+++ b/docs/help/terminfo.mdx
@@ -70,6 +70,14 @@ col 31, terminal 'xterm-ghostty': older tic versions may treat the description
 field as an alias` which can be safely ignored.
 
 <Note>
+`tic` will normally place its results in the system database,
+`/usr/share/terminfo`.  This location can be overridden with the `TERMINFO`
+environment variable.  If `TERMINFO` is not set and `tic` cannot write to
+the system location, it will place the results in `$HOME/.terminfo` if it
+exists.  `man tic` for details.
+</Note>
+
+<Note>
 **macOS versions before Sonoma cannot use the system-bundled `infocmp`.**
 The bundled version of `ncurses` is too old to emit a terminfo entry that can be
 read by more recent versions of `tic`, and the command will fail with a bunch


### PR DESCRIPTION
This commit adds a note about where the `tic` command writes its output.  I was nervous about access to the system terminfo bits and spent a few minutes reading the terminfo man pages to convince myself that the command wouldn't surprise me.

Thought it might be useful to add a note for the next folks to come along.