### PR TITLE
Ubuntu | Replace dpkg with apt

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -226,7 +226,7 @@ downloading the .deb for your Ubuntu version from the
 as below:
 
 ```sh
-sudo dpkg -i ghostty_*.deb
+sudo apt install ./ghostty_*.deb
 ```
 
 <Warning>


### PR DESCRIPTION
If the package has dependencies that are not already installed, dpkg -i will fail, while apt  will automatically fetch and install the missing dependencies as well.  Also most users are more familiar with apt that they already use for installing packages and updates