### PR TITLE
Sets the current year for the copyright in the footer

### DIFF
--- a/src/layouts/nav-footer-layout/index.tsx
+++ b/src/layouts/nav-footer-layout/index.tsx
@@ -24,6 +24,8 @@ type NavFooterLayoutProps = RootLayoutProps & {
 };
 
 export default function NavFooterLayout(props: NavFooterLayoutProps) {
+  const currentYear = new Date().getFullYear();
+
   const { children, docsNavTree, ...otherProps } = props;
   return (
     <RootLayout {...otherProps}>
@@ -44,7 +46,7 @@ export default function NavFooterLayout(props: NavFooterLayoutProps) {
             href: "/download",
           },
         ]}
-        copyright="© 2024 Mitchell Hashimoto"
+        copyright={`© ${currentYear} Mitchell Hashimoto`}
       />
     </RootLayout>
   );


### PR DESCRIPTION
Currently, the year in the footer is 2024:

<img width="1005" alt="Screenshot 2025-01-22 at 09 39 56" src="https://github.com/user-attachments/assets/3a6beb1f-2702-42eb-8130-85f2a816b8ff" />

I've updated the copyright string so it will set the actual year every time the website builds.
