### PR TITLE
fix: enable rendering of docs page, exclude from nav tree

### DIFF
--- a/src/lib/nav-tree-to-breadcrumbs.ts
+++ b/src/lib/nav-tree-to-breadcrumbs.ts
@@ -24,6 +24,8 @@ export function navTreeToBreadcrumbs(
 
   // Go through each URL segment & determine the breadcrumb to push to our array
   while (segments.length) {
+    const currentSegment = segments[0];
+
     // Find the Node which represents the URL segment we're on
     var nextNode: FolderNode | LinkNode | undefined = currentNavTree.find(
       (node) => {
@@ -35,8 +37,17 @@ export function navTreeToBreadcrumbs(
         return false;
       },
     ) as FolderNode | LinkNode | undefined;
+
     if (typeof nextNode === "undefined") {
-      throw new Error("Could not load next segment");
+      segments.map((name) => {
+        accumulatedPath += `/${name}`; // Accumulate the path with the current segment
+        breadcrumbs.push({
+          text: name, // Use segment (file name) as the breadcrumb title
+          href: docsRootPath + accumulatedPath, // Link to the full slug path
+         });
+      })
+
+      break;
     }
 
     if (nextNode.type === "folder") {


### PR DESCRIPTION
This pull request includes changes to the `navTreeToBreadcrumbs` function in the `src/lib/nav-tree-to-breadcrumbs.ts` file to improve error handling and breadcrumb generation.

Improvements to `navTreeToBreadcrumbs` function:

* Added a variable `currentSegment` to store the current URL segment being processed.
* Updated error handling to map remaining segments to breadcrumb items instead of throwing an error when the next node is undefined. This includes accumulating the path and creating breadcrumb objects with the segment name and full slug path.

### Screenshots
![CleanShot 2025-01-28 at 01 13 26](https://github.com/user-attachments/assets/6a9d3481-e8e1-4ed5-a5cb-81d571b83a6f)

![CleanShot 2025-01-28 at 01 14 01](https://github.com/user-attachments/assets/c5001d6b-fdc5-4b5f-a2ac-ae7a7b376f97)

![CleanShot 2025-01-28 at 01 14 09](https://github.com/user-attachments/assets/9b5ef12c-2cfd-42e4-aac8-cd7424c09d41)

### Fixed 
#286 

