### PR TITLE
Add ghostty-org/ghostty#5285 to 1.1.0 release notes (Change default key bindings to capture full screen contents)

### DIFF
--- a/docs/install/release-notes/1-1-0.mdx
+++ b/docs/install/release-notes/1-1-0.mdx
@@ -201,6 +201,9 @@ In each section, we try to sort improvements before bug fixes.
 - A new keybinding action `close_tab` can be used to close the tab and
   all splits within the tab. This works on both macOS and GTK builds.
   [#4331](https://github.com/ghostty-org/ghostty/pull/4331)
+- Update default `ctrl+shift+j`/`ctrl+shift+alt+j` keybindings to capture full
+  screen contents.
+  [#5285](https://github.com/ghostty-org/ghostty/pull/5285)
 - IPv6 URLs are now automatically turned into hyperlinks.
   [#4743](https://github.com/ghostty-org/ghostty/issues/4743)
 - Filepaths without an explicit `file://` protocol can now be clicked


### PR DESCRIPTION
Add https://github.com/ghostty-org/ghostty/pull/5285 to `1.1.0` release notes: Change default key bindings to capture full screen contents (`write_screen_file`)

This seems like a notable improvement (self-described but I think it should go somewhere :shrug:). Feel free to nit a more correct location in the list. I tried to just put it next to other keybinding improvements.