### PR TITLE
docs: Fix "performable" header

### DIFF
--- a/docs/config/keybind/index.mdx
+++ b/docs/config/keybind/index.mdx
@@ -117,7 +117,7 @@ keybinds will always consume the input regardless of this setting.
 Since they are not associated with a specific terminal surface,
 they're never encoded.
 
-#### `performabe:`
+#### `performable:`
 
 Only consume the input if the action is able to be performed. For example,
 the `copy_to_clipboard` action will only consume the input if there is a


### PR DESCRIPTION
Header typo.