### PR TITLE
Note about copying $HOME/.terminfo to system database

### DIFF
--- a/docs/help/terminfo.mdx
+++ b/docs/help/terminfo.mdx
@@ -76,12 +76,12 @@ field as an alias` which can be safely ignored.
 environment variable.  If `TERMINFO` is not set and `tic` cannot write to
 the system location, it will place the results in `$HOME/.terminfo` if it
 exists. If the results were placed in `$HOME/.terminfo` it might be a good idea
-to symlink them to the system database which might help when running `sudo`. 
+to copy them to the system database which might help when running `sudo`. 
 `man tic` for details.
 
 ```sh
-sudo ln -s $HOME/.terminfo/x/xterm-ghostty /usr/share/terminfo/x/xterm-ghostty
-sudo ln -s $HOME/.terminfo/g/ghostty /usr/share/terminfo/g/ghostty
+sudo cp $HOME/.terminfo/x/xterm-ghostty /usr/share/terminfo/x/xterm-ghostty
+sudo cp $HOME/.terminfo/g/ghostty /usr/share/terminfo/g/ghostty
 ```
 </Note>
 

--- a/docs/help/terminfo.mdx
+++ b/docs/help/terminfo.mdx
@@ -75,7 +75,14 @@ field as an alias` which can be safely ignored.
 `/usr/share/terminfo`.  This location can be overridden with the `TERMINFO`
 environment variable.  If `TERMINFO` is not set and `tic` cannot write to
 the system location, it will place the results in `$HOME/.terminfo` if it
-exists.  `man tic` for details.
+exists. If the results were placed in `$HOME/.terminfo` it might be a good idea
+to symlink them to the system database which might help when running `sudo`. 
+`man tic` for details.
+
+```sh
+sudo ln -s $HOME/.terminfo/x/xterm-ghostty /usr/share/terminfo/x/xterm-ghostty
+sudo ln -s $HOME/.terminfo/g/ghostty /usr/share/terminfo/g/ghostty
+```
 </Note>
 
 <Note>


### PR DESCRIPTION
Running `tic` with a non-privileged ssh user will result in the terminfo db only being updated for that user. Running sudo commands will not benefit from the updated database. Symlinking it or copying it to the system db resolves this.