### PR TITLE
add 1.1.2 release entry & link

### DIFF
--- a/docs/install/release-notes/index.mdx
+++ b/docs/install/release-notes/index.mdx
@@ -5,6 +5,7 @@ description: |-
   release notes.
 ---
 
+- [1.1.2](/docs/install/release-notes/1-1-2) - Released on February 13, 2025
 - [1.1.1](/docs/install/release-notes/1-1-1) – Released on February 13, 2025
 - [1.1.0](/docs/install/release-notes/1-1-0) – Released on January 30, 2025
 - [1.0.1](/docs/install/release-notes/1-0-1) – Released on December 31, 2024


### PR DESCRIPTION
I noticed the Release Notes "Overview" page does not include an entry for `1.1.2`.  Just a simple PR to add that to remain consistent with previous iterations.