### PR TITLE
Propose another community Debian repo

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -167,7 +167,7 @@ of caution should be taken when installing them.
 
 ### Debian
 
-Ghostty is available in [this community-maintained repository](https://github.com/clayrisser/debian-ghostty/).
+Ghostty is available in [this community-maintained repository](https://gitlab.com/gfa/ghostty-for-debian).
 
 Instructions for each version are available in the README of the repository.
 


### PR DESCRIPTION
The current Debian repo does not provide up to date packages or an apt repo.

This change proposes another repo that I maintain, builds packages from a pipeline, and maintains an apt repo for bookworm.