### PR TITLE
Update 1-1-1.mdx: fix hyperlink

### DIFF
--- a/docs/install/release-notes/1-1-1.mdx
+++ b/docs/install/release-notes/1-1-1.mdx
@@ -11,10 +11,11 @@ release. We've also snuck in some nice improvements to existing
 features.
 
 <Important>
+
 A critical regression was found in Ghostty 1.1.1 on macOS that caused
 control-modified keys to not work properly in programs using the Kitty
 Keyboard protocol such as Neovim and Fish 4.0. This was fixed in
-[1.1.2](/docs/install/release-notes/1-1-2).
+[1.1.2](/docs/install/release-notes/1-1-2.mdx).
 </Important>
 
 ## Highlights


### PR DESCRIPTION
Newline necessary after html tag to trigger parsing of markdown hyperlink

File extension `.mdx` needed for correct url