### PR TITLE
Right click to copy config

### DIFF
--- a/docs/config/reference.mdx
+++ b/docs/config/reference.mdx
@@ -1556,6 +1556,23 @@ paste is always enabled even if this is `false`.
 
 The default value is true on Linux and macOS.
 
+## `copy-on-right-click`
+
+Whether to copy selected text to the clipboard on right mouse click. `true`
+will prefer to copy to the selection clipboard, otherwise it will copy to
+the system clipboard.
+
+The value `clipboard` will always copy text to the selection clipboard
+as well as the system clipboard.
+
+Middle-click paste will always use the selection clipboard. Middle-click
+paste is always enabled even if this is `false`.
+
+The default value is false for all systems.
+
+At present this will only disable the context menu on Linux in the future
+this shoul also disable the context menu on macOS
+
 ## `click-repeat-interval`
 
 The time in milliseconds between clicks to consider a click a repeat

--- a/docs/config/reference.mdx
+++ b/docs/config/reference.mdx
@@ -1571,7 +1571,7 @@ paste is always enabled even if this is `false`.
 The default value is false for all systems.
 
 At present this will only disable the context menu on Linux in the future
-this shoul also disable the context menu on macOS
+this should also disable the context menu on macOS
 
 ## `click-repeat-interval`
 


### PR DESCRIPTION
Adds docs for right click to copy support to ghostty.

[Pull request for this feature](https://github.com/ghostty-org/ghostty/pull/5935)