### PR TITLE
Fix: monospace fonts not rendering properly with custom fonts disabled

### DIFF
--- a/src/components/codeblock/CodeBlock.module.css
+++ b/src/components/codeblock/CodeBlock.module.css
@@ -9,7 +9,14 @@
 
 .codeBlock code {
   padding: 16px;
-  font-family: inherit;
+  /* Fix for https://github.com/ghostty-org/website/issues/312
+  * In the case a user has custom fonts disabled, this ensures
+  * that the code block is still readable. 
+  *
+  * Additionally, `inherit` here didn't seem to be working? So we're
+  * setting the font-family explicitly. 
+  */
+  font-family: var(--jetbrains-mono), monospace;
 }
 
 .copyButton {
@@ -40,4 +47,3 @@
 .copyButtonSuccess {
   color: var(--atom-one-green);
 }
-

--- a/src/components/text/Text.module.css
+++ b/src/components/text/Text.module.css
@@ -5,7 +5,7 @@
       font-weight: 400;
     }
   }
-  &.weightRegular {
+  &.weightRegular{
     font-weight: 400;
     & strong {
       font-weight: 500;
@@ -17,9 +17,7 @@
       font-weight: 600;
     }
   }
-  &p,
-  &span,
-  &li {
+  &p, &span, &li {
     font-size: 16px;
     line-height: 1.4em;
     color: var(--gray-4);
@@ -38,48 +36,43 @@
       line-height: 1.25em;
     }
   }
-  &h1,
-  &h2,
-  &h3,
-  &h4,
-  &h5,
-  &h6 {
+  &h1, &h2, &h3, &h4, &h5, &h6 {
     color: var(--gray-9);
     line-height: 1.2em;
   }
   &h1 {
     font-size: 35px;
-    @media (max-width: 768px) {
+    @media(max-width: 768px) {
       font-size: 30px;
     }
   }
   &h2 {
     font-size: 25px;
-    @media (max-width: 768px) {
+    @media(max-width: 768px) {
       font-size: 22px;
     }
   }
   &h3 {
     font-size: 18px;
-    @media (max-width: 768px) {
+    @media(max-width: 768px) {
       font-size: 16px;
     }
   }
   &h4 {
     font-size: 16px;
-    @media (max-width: 768px) {
+    @media(max-width: 768px) {
       font-size: 14px;
     }
   }
   &h5 {
     font-size: 14px;
-    @media (max-width: 768px) {
+    @media(max-width: 768px) {
       font-size: 12px;
     }
   }
   &h6 {
     font-size: 12px;
-    @media (max-width: 768px) {
+    @media(max-width: 768px) {
       font-size: 10px;
     }
   }

--- a/src/components/text/Text.module.css
+++ b/src/components/text/Text.module.css
@@ -5,7 +5,7 @@
       font-weight: 400;
     }
   }
-  &.weightRegular{
+  &.weightRegular {
     font-weight: 400;
     & strong {
       font-weight: 500;
@@ -17,7 +17,9 @@
       font-weight: 600;
     }
   }
-  &p, &span, &li {
+  &p,
+  &span,
+  &li {
     font-size: 16px;
     line-height: 1.4em;
     color: var(--gray-4);
@@ -36,48 +38,57 @@
       line-height: 1.25em;
     }
   }
-  &h1, &h2, &h3, &h4, &h5, &h6 {
+  &h1,
+  &h2,
+  &h3,
+  &h4,
+  &h5,
+  &h6 {
     color: var(--gray-9);
     line-height: 1.2em;
   }
   &h1 {
     font-size: 35px;
-    @media(max-width: 768px) {
+    @media (max-width: 768px) {
       font-size: 30px;
     }
   }
   &h2 {
     font-size: 25px;
-    @media(max-width: 768px) {
+    @media (max-width: 768px) {
       font-size: 22px;
     }
   }
   &h3 {
     font-size: 18px;
-    @media(max-width: 768px) {
+    @media (max-width: 768px) {
       font-size: 16px;
     }
   }
   &h4 {
     font-size: 16px;
-    @media(max-width: 768px) {
+    @media (max-width: 768px) {
       font-size: 14px;
     }
   }
   &h5 {
     font-size: 14px;
-    @media(max-width: 768px) {
+    @media (max-width: 768px) {
       font-size: 12px;
     }
   }
   &h6 {
     font-size: 12px;
-    @media(max-width: 768px) {
+    @media (max-width: 768px) {
       font-size: 10px;
     }
   }
   & > code {
-    font-family: var(--jetbrains-mono);
+    /* Fix for https://github.com/ghostty-org/website/issues/312
+  * In the case a user has custom fonts disabled, this ensures
+  * that the code block is still readable. 
+  */
+    font-family: var(--jetbrains-mono), monospace;
     border: 1px solid var(--gray-3);
     background: var(--gray-2);
     border-radius: 4px;

--- a/src/components/vt-sequence/VTSequence.module.css
+++ b/src/components/vt-sequence/VTSequence.module.css
@@ -7,7 +7,11 @@
   align-items: flex-start;
 
   & .unimplemented {
-    font-family: var(--jetbrains-mono);
+    /* Fix for https://github.com/ghostty-org/website/issues/312
+  * In the case a user has custom fonts disabled, this ensures
+  * that the code block is still readable. 
+  */
+    font-family: var(--jetbrains-mono), monospace;
     font-size: 14px;
     background: var(--atom-one-red);
     color: var(--gray-0);
@@ -26,7 +30,7 @@
     flex-grow: 1;
     width: 100%;
     display: flex;
-    font-family: var(--jetbrains-mono);
+    font-family: var(--jetbrains-mono), monospace;
     list-style: none;
 
     & .vtelem {


### PR DESCRIPTION
Fix for #312 

*Should* properly fix font rendering for the Text, VT, and Codeblock components.