### PR TITLE
Fix broken link to screen

### DIFF
--- a/docs/vt/concepts/cursor.mdx
+++ b/docs/vt/concepts/cursor.mdx
@@ -17,7 +17,7 @@ used for location-sensitive control sequences. For example,
 when an [erase line control sequence](/docs/vt/csi/el) is
 executed, the cursor determines the first line to erase.
 
-The terminal has a single cursor [per screen](/docs/concepts/screen).
+The terminal has a single cursor [per screen](/docs/vt/concepts/screen).
 **Note that this document is about the cursor as it relates
 to the [terminal API](/docs/vt).** Applications such as editors may
 have their own concept known as a "cursor" that is completely


### PR DESCRIPTION
This change the link from [this](https://ghostty.org/docs/concepts/screen) that is a 404 to [this](https://ghostty.org/docs/vt/concepts/screen) that is the placeholder todo screen page.