### PR TITLE
docs: fix relative links

### DIFF
--- a/docs/vt/control/lf.mdx
+++ b/docs/vt/control/lf.mdx
@@ -8,4 +8,4 @@ description: Move the cursor down one line, scrolling if necessary.
 This is an alias for [index (IND)](/docs/vt/esc/ind).
 
 If [linefeed mode (mode 20)](#TODO) is enabled, perform a
-[carriage return](/docs/vt/esc/cr) after the IND operation.
+[carriage return](/docs/vt/control/cr) after the IND operation.

--- a/docs/vt/csi/decslrm.mdx
+++ b/docs/vt/csi/decslrm.mdx
@@ -7,7 +7,7 @@ description: Set the left and right margins.
 
 Sets the left and right margins, otherwise known as the scroll region.
 To learn more about scroll regions in general, see
-[Set Top and Bottom Margins](/vt/decstbm).
+[Set Top and Bottom Margins](/docs/vt/csi/decstbm).
 
 Parameters `l` and `r` are integer values. If either value is zero the
 value will be reset to default values. The default value for `l` is `1`

--- a/docs/vt/csi/decstbm.mdx
+++ b/docs/vt/csi/decstbm.mdx
@@ -28,7 +28,7 @@ the full screen.
 
 The top and bottom margin constitute what is known as the _scroll region_.
 The scroll region impacts the operation of many sequences such as
-[insert line](/vt/il), [cursor down](/vt/cud), etc. Scroll regions are
+[insert line](/docs/vt/csi/il), [cursor down](/docs/vt/csi/cud), etc. Scroll regions are
 an effective and efficient way to constraint terminal modifications to a
 rectangular region of the screen.
 

--- a/docs/vt/csi/ed.mdx
+++ b/docs/vt/csi/ed.mdx
@@ -18,7 +18,7 @@ If [Select Character Selection Attribute (DECSCA)](#TODO) is enabled
 or was the most recently enabled protection mode on the currently active screen,
 protected attributes are ignored. Otherwise, protected attributes will be
 respected. For more details on this specific logic for protected attribute
-handling, see [Erase Character (ECH)](/vt/ech).
+handling, see [Erase Character (ECH)](/docs/vt/csi/ech).
 
 For all operations, if a multi-cell character would be split, erase the full multi-cell
 character. For example, if "橋" is printed and the erase would only erase the

--- a/docs/vt/csi/el.mdx
+++ b/docs/vt/csi/el.mdx
@@ -17,14 +17,14 @@ If [Select Character Selection Attribute (DECSCA)](#TODO) is enabled
 or was the most recently enabled protection mode on the currently active screen,
 protected attributes are ignored. Otherwise, protected attributes will be
 respected. For more details on this specific logic for protected attribute
-handling, see [Erase Character (ECH)](/vt/ech).
+handling, see [Erase Character (ECH)](/docs/vt/csi/ech).
 
 For all operations, if a multi-cell character would be split, erase the full multi-cell
 character. For example, if "橋" is printed and the erase would only erase the
 first or second cell of the two-cell character, both cells should be erased.
 
 If `n` is `0`, perform an **erase line right** operation. Erase line right
-is equivalent to [Erase Character (ECH)](/vt/ech) with `n` set to the total
+is equivalent to [Erase Character (ECH)](/docs/vt/csi/ech) with `n` set to the total
 remaining columns from the cursor to the end of the line (and including
 the cursor). If the line is softwrapped, only the single row is erased;
 it does not erase through the wrap. Further, the wrap state of the row is

--- a/docs/vt/csi/su.mdx
+++ b/docs/vt/csi/su.mdx
@@ -10,7 +10,7 @@ description: |-
 The parameter `n` must be an integer greater than or equal to 1. If `n` is less than
 or equal to 0, adjust `n` to be 1. If `n` is omitted, `n` defaults to 1.
 
-This sequence executes [Delete Line (DL)](/vt/dl) with the cursor position
+This sequence executes [Delete Line (DL)](/docs/vt/csi/dl) with the cursor position
 set to the top of the scroll region. There are some differences from DL
 which are explained below.
 

--- a/docs/vt/csi/vpr.mdx
+++ b/docs/vt/csi/vpr.mdx
@@ -6,7 +6,7 @@ description: |-
 
 <VTSequence sequence={["CSI", "Py", "e"]} />
 
-This sequence performs [cursor position (CUP)](/vt/cup) with `y` set
+This sequence performs [cursor position (CUP)](/docs/vt/csi/cup) with `y` set
 to the current cursor row plus `y` and `x` set to the current cursor column.
 There is no additional or different behavior for using `VPR`.
 

--- a/docs/vt/esc/ris.mdx
+++ b/docs/vt/esc/ris.mdx
@@ -15,7 +15,7 @@ The full reset operation does the following:
 - Reset charsets to the default
 - Reset [cursor key mode (DECCKM)](#TODO)
 - Reset [disable keyboard input (KAM)](#TODO)
-- Reset [application keypad mode](/vt/deckpnm)
+- Reset [application keypad mode](/docs/vt/esc/deckpnm)
 - Reset xterm keyboard modifier state to the default
 - Disable cursor [protected attribute](#TODO)
 - Disable any [protected area](#TODO)


### PR DESCRIPTION
This is like #317, but I did a more thorough search for broken links.

I found these two links to pages that do not yet exist. I'm not sure if I should delete the href and replace it with `#TODO` or leave it as is:
- `/vt/modes/origin` (maybe this should be `docs/vt/modes/origin`, with the `docs/` at the beginning) on `docs/vt/esc/decsc.mdx` and `docs/vt/csi/cht.mdx`.
- `/docs/vt/csi/hts` on `docs/vt/csi/cht.mdx` and `docs/vt/csi/cbt.mdx`.
