### PR TITLE
fix: include libxml2-utils to debian dependencies

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -115,7 +115,7 @@ sudo pacman -S gtk4 libadwaita blueprint-compiler gettext
 #### Debian and Ubuntu
 
 ```sh
-sudo apt install libgtk-4-dev libadwaita-1-dev git blueprint-compiler gettext
+sudo apt install libgtk-4-dev libadwaita-1-dev git blueprint-compiler gettext libxml2-utils
 ```
 
 On Debian unstable/testing, the `gcc-multilib` package is also required


### PR DESCRIPTION
Without this, the following error shows:

```
xml-stripblanks preprocessing requested, but XMLLINT is not set, and xmllint is not in PATH
```