### PR TITLE
Add `+list-keybinds` note for people searching for default keybindings

### DIFF
--- a/docs/config/keybind/index.mdx
+++ b/docs/config/keybind/index.mdx
@@ -9,6 +9,14 @@ The configuration reference has detailed reference documentation
 for the option, but this page will give a high-level overview
 of how to specify keybindings in Ghostty.
 
+<Note>
+The CLI command `list-keybinds` is used to list all the available keybinds for Ghostty.  
+You can run this to see the default ones:
+```sh
+ghostty +list-keybinds --default
+```
+</Note>
+
 The basic syntax of a keybinding configuration is:
 
 ```ini


### PR DESCRIPTION
I suggest adding a hint on how to find the default keybindings to the docs.

I personally first went to [keybindings overview](https://ghostty.org/docs/config/keybind) and didn’t find them there.
Using a search engine you can find this: https://gist.github.com/hensg/43bc71c21d1f79385892352a390aa2ca 
See the comments there for more people describing having the same problems with finding the default keybindings.

I read CONTRIBUTING.md and take the risk as it seems to be a pattern that people do not find this cli command.
There is also already a discussion which would be closed by this PR: https://github.com/ghostty-org/ghostty/discussions/4517