### PR TITLE
Explicitly specify `ghostty` in the infocmp command

### DIFF
--- a/docs/help/terminfo.mdx
+++ b/docs/help/terminfo.mdx
@@ -63,7 +63,7 @@ The following one-liner will export the terminfo entry from your host and
 import it on the remote machine:
 
 ```sh
-infocmp -x | ssh YOUR-SERVER -- tic -x -
+infocmp -x ghostty | ssh YOUR-SERVER -- tic -x -
 ```
 
 The `tic` command on the server may give the warning `"<stdin>", line 2,


### PR DESCRIPTION
Something that seems to be pretty common is for people to run the `infocmp` command in a terminal emulator other than Ghostty, presumably as a stop-gap until they fix their terminfo.  This makes the command do absolutely nothing and has been the source of confusion on multiple occassions.

`ghostty` is used instead of `xterm-ghostty` as ncurses doesn't ship `xterm-ghostty` and both seem to generate the same output (apart from the comment at the top).