### PR TITLE
Specify using `xterm-ghostty` instead of `ghostty` in the infocmp command

### DIFF
--- a/docs/help/terminfo.mdx
+++ b/docs/help/terminfo.mdx
@@ -63,7 +63,7 @@ The following one-liner will export the terminfo entry from your host and
 import it on the remote machine:
 
 ```sh
-infocmp -x ghostty | ssh YOUR-SERVER -- tic -x -
+infocmp -x xterm-ghostty | ssh YOUR-SERVER -- tic -x -
 ```
 
 The `tic` command on the server may give the warning `"<stdin>", line 2,


### PR DESCRIPTION
Quoting myself from #325:
> `ghostty` is used instead of `xterm-ghostty` as ncurses doesn't ship `xterm-ghostty` and both seem to generate the same output (apart from the comment at the top).

That reasoning appears to have backfired: recently, in [a Discord #help post], the command did not work for somebody because their system had both ncurses' `ghostty` and Ghostty's `xterm-ghostty` installed, resulting in `ghostty` being copied over when `xterm-ghostty` was expected.  I had thought ncurses had a fallback for `xterm-ghostty` specified despite their reluctance to name the terminfo file `xterm-ghostty`, but [its database doesn't seem to do that], so their `ghostty` terminfo doesn't actually work because the default `$TERM` value is `xterm-ghostty`.

I'm not sure what to do about this, but every packager so far appears to have packaged both ncurses' `ghostty` and Ghostty's `xterm-ghostty`, so I assume that anybody in the same situation as the author of the aforementioned `#help` post also has `xterm-ghostty` installed.  Besides, if `xterm-ghostty` wasn't installed, they would have issues locally anyway and would likely end up making a `#help` post or a GitHub Discussion about it where somebody could direct them on what to do (which is probably setting `term = ghostty`), so I doubt this would cause too many issues that weren't going to arise anyway.

[a Discord #help post]: https://discord.com/channels/1005603569187160125/1371227963063930962
[its database doesn't seem to do that]: https://invisible-island.net/ncurses/terminfo.src-entries.html#tic-ghostty