### PR TITLE
docs: remove links to missing pages and replace with '#TODO'

### DIFF
--- a/docs/vt/csi/cbt.mdx
+++ b/docs/vt/csi/cbt.mdx
@@ -15,7 +15,7 @@ the leftmost valid column and the operation completes. Repeat this process
 `n` times.
 
 Tabstops are dynamic and can be set with escape sequences such as
-[horizontal tab set (HTS)](/docs/vt/csi/hts), [tab clear (TBC)](/docs/vt/csi/tbc), etc.
+[horizontal tab set (HTS)](#TODO), [tab clear (TBC)](/docs/vt/csi/tbc), etc.
 A terminal emulator may default tabstops at any interval, though an interval
 of 8 spaces is most common.
 

--- a/docs/vt/csi/cht.mdx
+++ b/docs/vt/csi/cht.mdx
@@ -18,7 +18,7 @@ the rightmost valid column and the operation completes. Repeat this process
 `n` times.
 
 Tabstops are dynamic and can be set with escape sequences such as
-[horizontal tab set (HTS)](/docs/vt/csi/hts), [tab clear (TBC)](/docs/vt/csi/tbc), etc.
+[horizontal tab set (HTS)](#TODO), [tab clear (TBC)](/docs/vt/csi/tbc), etc.
 A terminal emulator may default tabstops at any interval, though an interval
 of 8 spaces is most common.
 

--- a/docs/vt/csi/dsr.mdx
+++ b/docs/vt/csi/dsr.mdx
@@ -15,7 +15,7 @@ to the program with `ESC [ 0 n` to indicate no malfunctions.
 
 If `n = 6`, the _cursor position_ is requested. The terminal responds to
 the program in the format `ESC [ y ; x R` where `y` is the row and `x`
-is the column, both one-indexed. If [origin mode (DEC Mode 6)](/vt/modes/origin)
+is the column, both one-indexed. If [origin mode (DEC Mode 6)](#TODO)
 is enabled, the reported cursor position is relative to the top-left of the
 scroll region.
 

--- a/docs/vt/esc/decsc.mdx
+++ b/docs/vt/esc/decsc.mdx
@@ -13,7 +13,7 @@ The following attributes are saved:
 - Character sets
 - Pending wrap state
 - SGR attributes
-- [Origin mode (DEC Mode 6)](/vt/modes/origin)
+- [Origin mode (DEC Mode 6)](#TODO)
 
 Only one cursor can be saved at any time. If save cursor is repeated, the
 previously save cursor is overwritten.


### PR DESCRIPTION
There are a few pages (4) that link to 2 docs pages that are `#TODO` (they are missing now). So I replace the `href` with a `#TODO` as suggested [here](https://github.com/ghostty-org/website/pull/318#issuecomment-2825472935) to avoid 404 errors.