### PR TITLE
docs: add missing fedora dependency

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -136,13 +136,13 @@ Ubuntu 23.10 is 6.5.0 which has a bug which
 On Fedora variants, use
 
 ```sh
-sudo dnf install gtk4-devel zig libadwaita-devel blueprint-compiler gettext
+sudo dnf install gtk4-devel gtk4-layer-shell-devel zig libadwaita-devel blueprint-compiler gettext
 ```
 
 On Fedora Atomic variants, use
 
 ```sh
-rpm-ostree install gtk4-devel zig libadwaita-devel blueprint-compiler gettext
+rpm-ostree install gtk4-devel gtk4-layer-shell-devel zig libadwaita-devel blueprint-compiler gettext
 ```
 
 #### Gentoo


### PR DESCRIPTION
I needed to add `gtk4-layer-shell-devel` dependency building on Fedora 42.