### PR TITLE
fix: add missing package for build on Arch Linux

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -109,7 +109,7 @@ doas apk add gtk4.0-dev libadwaita-dev pkgconf ncurses blueprint-compiler gettex
 #### Arch Linux
 
 ```sh
-sudo pacman -S gtk4 libadwaita blueprint-compiler gettext
+sudo pacman -S gtk4 gtk4-layer-shell libadwaita blueprint-compiler gettext
 ```
 
 #### Debian and Ubuntu


### PR DESCRIPTION
The package `gtk4-layer-shell` is needed to build Ghostty using Arch Linux.