### PR TITLE
update libgtk4-layer-shell-dev for ubuntu build instructions

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -115,7 +115,7 @@ sudo pacman -S gtk4 gtk4-layer-shell libadwaita blueprint-compiler gettext
 #### Debian and Ubuntu
 
 ```sh
-sudo apt install libgtk-4-dev libadwaita-1-dev git blueprint-compiler gettext libxml2-utils 
+sudo apt install libgtk-4-dev libadwaita-1-dev git blueprint-compiler gettext libxml2-utils
 ```
 
 On Debian unstable/testing, the `gcc-multilib` package is also required

--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -115,11 +115,14 @@ sudo pacman -S gtk4 gtk4-layer-shell libadwaita blueprint-compiler gettext
 #### Debian and Ubuntu
 
 ```sh
-sudo apt install libgtk-4-dev libadwaita-1-dev git blueprint-compiler gettext libxml2-utils
+sudo apt install libgtk-4-dev libadwaita-1-dev git blueprint-compiler gettext libxml2-utils 
 ```
 
 On Debian unstable/testing, the `gcc-multilib` package is also required
 for building.
+
+On Ubuntu 24.10+ and Debian trixie+, `libgtk4-layer-shell-dev` is also
+needed for building.
 
 <Note>
 **A recent GTK is required for Ghostty to work with Nvidia (GL) drivers


### PR DESCRIPTION
It seems like without this package, ghostty will not build after https://github.com/ghostty-org/ghostty/pull/6706.

However, it seems like libgtk4-layer-shell-dev is only available in Ubuntu 24.10+ and Debian trixie+. I've only tried this on a Ubuntu 25.04 machine tho.