### PR TITLE
fedora: change suggested COPR

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -200,10 +200,10 @@ These are user-maintained packages and not official Debian packages.
 
 ### Fedora
 
-Ghostty is available in [Fedora COPR](https://copr.fedorainfracloud.org/coprs/pgdev/ghostty/).
+Ghostty is available in [Fedora COPR](https://copr.fedorainfracloud.org/coprs/scottames/ghostty/).
 
 ```sh
-dnf copr enable pgdev/ghostty
+dnf copr enable scottames/ghostty
 dnf install ghostty
 ```
 


### PR DESCRIPTION
Current COPR is still on 1.1.2 and it seems like the author is not responding to issues [^1].

I'm proposing to start suggesting a better maintained package by @scottames.

I'm not suggesting changes to Atomic desktops as I'm not familiar with package compatibility there (maybe it's trivial).

[^1]:https://gitlab.com/pgill/ghostty-rpm/-/issues/4