### PR TITLE
fix(docs): theme lookup happens in `XDG_CONFIG_HOME/ghostty/themes`

### DIFF
--- a/docs/config/reference.mdx
+++ b/docs/config/reference.mdx
@@ -404,7 +404,7 @@ systems with case-sensitive filesystems. It is an error for a theme name to
 include path separators unless it is an absolute pathname.
 
 The first directory is the `themes` subdirectory of your Ghostty
-configuration directory. This is `$XDG_CONFIG_DIR/ghostty/themes` or
+configuration directory. This is `$XDG_CONFIG_HOME/ghostty/themes` or
 `~/.config/ghostty/themes`.
 
 The second directory is the `themes` subdirectory of the Ghostty resources
@@ -2387,4 +2387,3 @@ Changing this configuration requires a full restart of
 Ghostty to take effect.
 
 This only works on macOS since only macOS has an auto-update feature.
-


### PR DESCRIPTION
I believe this is a typo. Seems like the [docs](https://ghostty.org/docs/features/theme#file-location) confirm it elsewhere, too.

Thanks for Ghostty!

---

💖