### PR TITLE
docs: generalize nixpkgs unstable to nixpkgs

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -86,7 +86,7 @@ emerge -av ghostty
 
 ### NixOS
 
-Ghostty is available in [nixpkgs unstable](https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=ghostty).
+Ghostty is available in [nixpkgs](https://search.nixos.org/packages?from=0&size=50&sort=relevance&type=packages&query=ghostty).
 
 ```
 environment.systemPackages = [


### PR DESCRIPTION
Ghostty is also in nixpkgs stable channel nowadays, so this generalizes the description from `nixpkgs unstable` to `nixpkgs`