### PR TITLE
tip: update libadwaita build dependency notice

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -85,7 +85,7 @@ because Ghostty will build everything else statically by default.
 Required dependencies:
 
   * `gtk4`
-  * `libadwaita` (unless using `-Dgtk-adwaita=false`)
+  * `libadwaita`
   * `blueprint-compiler`
   * `pkg-config`
   * `gettext`


### PR DESCRIPTION
While building ghostty for RHEL-based distros I noticed that the `gtk-adwaita` build flag does not exist anymore.

Seems this is the case since https://github.com/ghostty-org/ghostty/pull/5749