### PR TITLE
Help page for OpenGL context issues

### DIFF
--- a/docs/help/gtk-opengl-context.mdx
+++ b/docs/help/gtk-opengl-context.mdx
@@ -1,0 +1,82 @@
+---
+title: GTK OpenGL Context Errors
+description: |-
+  In some situations, Ghostty may fail to start with an error about being
+  "unable to acquire an OpenGL context". This page adds more details about
+  this error and how to resolve it.
+---
+
+The Ghostty GTK application uses OpenGL for rendering. To render with
+OpenGL, Ghostty needs to first acquire an "OpenGL context" from GTK. This
+gives us the namespace to execute OpenGL commands.
+
+In rare situations, GTK may be unable to provide Ghostty with an OpenGL
+context. When this happens, Ghostty is unable to render anything and must
+show this error.
+
+This is **always an environment issue**. GTK provides Ghostty with the OpenGL
+context, and there isn't generaly anything Ghostty itself can do to resolve
+this directly. It is usually an issue regarding a library, driver, or OS
+package version. This page will attempt to provide some assistance in
+tracking down the issue.
+
+## Quick Fixes
+
+If you want to try to get Ghostty working quickly, try the following.
+
+1. **Install a [binary package](/docs/install/binary).** If you're building
+   from source, try using a binary package instead. Binary packages tend
+   to be built in a more controlled environment that works with a specific
+   distribution and its libraries.
+
+2. **Check your GPU drivers.** GPU drivers are a common cause of OpenGL
+   issues. Try updating or downgrading your GPU drivers, especially if
+   you're using proprietary drivers.
+
+3. **Build Ghostty from source using only system packages.** If you're using
+   the Nix development environment to build Ghostty, try building it
+   from source using only system packages. See the
+   [build from source](/docs/install/build) instructions to do this
+   (but ignore the "Building with Nix" section).
+
+<Important>
+  This section purposely avoids any detail in understanding the root cause of
+  this issue. If you want to better understand the root cause, please read below
+  this section.
+</Important>
+
+## Mismatched Library Versions
+
+A common cause of this error is mismatched library versions. The balance
+between GTK, [Mesa](https://mesa3d.org/), libX11/libwayland, and the kernel is
+a fragile one.
+
+**The first most common cause of this error is using the Nix development
+environment to build Ghostty.** We recommend this environment for development,
+but it does pin various versions of these libraries and they may be
+incompatible with your global system. **To fix: try to build Ghostty using
+only system dependency packages, or Ghostty itself from a system package.**
+You can follow the [build from source](/docs/install/build) instructions
+to do this (but ignore the "Building with Nix" section)
+
+**Another common cause is outdated system packages.**
+Linux distributions tend to handle this fragile balance for you, so the
+try to update your entire system (or, specifically the
+packages above, at least). This often brings your system back into a
+coherent state that allows Ghostty to work.
+
+**Check your GPU drivers.** Try updating or downgrading your GPU drivers.
+We've had many cases where GPU driver changes have broken OpenGL in GTK.
+
+## Known Historical Causes
+
+- [Mesa 25.2.0 Regression](https://gitlab.freedesktop.org/mesa/mesa/-/issues/13719).
+  Ghostty doesn't bundle a libwayland clent library, but building Ghostty
+  from source with the Nix development environment will use a different
+  libwayland client library than the system one.
+
+- [GTK4 + Nvidia + X11](https://gitlab.gnome.org/GNOME/gtk/-/issues/4950).
+  I don't know the exact combination required to trigger this, but it seems
+  in certain scenarios, the mixture of GTK4 (required by Ghostty), Nvidia,
+  and X11 can cause this issue. Changing driver versions or changing to
+  Wayland can resolve this.

--- a/docs/help/index.mdx
+++ b/docs/help/index.mdx
@@ -12,12 +12,13 @@ we try to document as many common issues and solutions as possible.
 
 ## Common Issues and Solutions
 
-| Issue | Solution |
-|-------|----------|
-| Error "missing or unsuitable terminal" when running commands or using SSH. | [Terminfo](/docs/help/terminfo) |
-| macOS window managers such as Yabai or Aerospace act strange | [macOS Tiling Window Managers](/docs/help/macos-tiling-wms) |
-| Ghostty has slow startup or high memory usage on Linux. | [GTK Single Instance](/docs/help/gtk-single-instance) |
-| macOS defaults to login shells | [macOS Login Shells](/docs/help/macos-login-shells)
+| Issue                                                                      | Solution                                                    |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| Error "missing or unsuitable terminal" when running commands or using SSH. | [Terminfo](/docs/help/terminfo)                             |
+| macOS window managers such as Yabai or Aerospace act strange               | [macOS Tiling Window Managers](/docs/help/macos-tiling-wms) |
+| Ghostty has slow startup or high memory usage on Linux.                    | [GTK Single Instance](/docs/help/gtk-single-instance)       |
+| "Unable to acquire OpenGL context" error on Linux                          | [GTK OpenGL Context](/docs/help/gtk-opengl-context)         |
+| macOS defaults to login shells                                             | [macOS Login Shells](/docs/help/macos-login-shells)         |
 
 ## Seeking Help
 
@@ -25,8 +26,8 @@ If the common issues and solutions above did not help and you
 can't find an answer in the documentation, the following resources
 are available:
 
-<CardLinks cards={
-  [
+<CardLinks
+  cards={[
     {
       title: "GitHub Discussions",
       description: "Search for and ask questions from the community on GitHub.",
@@ -36,7 +37,7 @@ are available:
       title: "Discord",
       description: "Real-time chat with the community. Community-moderated.",
       href: "https://discord.gg/ghostty",
-    }
+    },
   ]}
 />
 
@@ -45,8 +46,8 @@ are available:
 Please, please, please read the [contributing guide on GitHub](https://github.com/ghostty-org/ghostty/blob/main/CONTRIBUTING.md).
 
 <Important>
-**GitHub Issues is probably not the right place to go.** This project
-starts all bugs and feature requests as discussions on GitHub Discussions
-until more specific details are known. From there, we convert them into
-GitHub Issues as needed. See the contributing guide for more details.
+  **GitHub Issues is probably not the right place to go.** This project starts
+  all bugs and feature requests as discussions on GitHub Discussions until more
+  specific details are known. From there, we convert them into GitHub Issues as
+  needed. See the contributing guide for more details.
 </Important>

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -422,6 +422,11 @@
         },
         {
           "type": "link",
+          "path": "/gtk-opengl-context",
+          "title": "GTK OpenGL Context"
+        },
+        {
+          "type": "link",
           "path": "/macos-tiling-wms",
           "title": "macOS Tiling Window Managers"
         },


### PR DESCRIPTION
This adds a help page for OpenGL context issues. This will be linked by the error when this occurs in Ghostty.

PRed to main because nothing in here is tip-specific.