### PR TITLE
Display `mac-os-icons` options in table.

### DIFF
--- a/docs/config/reference.mdx
+++ b/docs/config/reference.mdx
@@ -2089,6 +2089,19 @@ Valid values:
    The `macos-icon-ghost-color` and `macos-icon-screen-color`
    configurations are required for this style.
 
+|Configuration Value|Icon|
+|----|----|
+|`official`|<img src="https://github.com/ghostty-org/ghostty/blob/main/macos/Assets.xcassets/AppIconImage.imageset/macOS-AppIcon-1024px.png?raw=true" alt="The official Ghostty icon" width="75" height="75" />|
+|`blueprint` |<img src="https://github.com/ghostty-org/ghostty/blob/main/macos/Assets.xcassets/Alternate%20Icons/BlueprintImage.imageset/macOS-AppIcon-1024px.png?raw=true" alt="Blueprint icon" width="75" height="75" /> |
+|`chalkboard` |<img src="https://github.com/ghostty-org/ghostty/blob/main/macos/Assets.xcassets/Alternate%20Icons/ChalkboardImage.imageset/macOS-AppIcon-1024px.png?raw=true" alt="Chalkboard icon" width="75" height="75" /> |
+|`microchip` |<img src="https://github.com/ghostty-org/ghostty/blob/main/macos/Assets.xcassets/Alternate%20Icons/MicrochipImage.imageset/macOS-AppIcon-1024px.png?raw=true" alt="Microchip icon" width="75" height="75" /> |
+|`glass` |<img src="https://github.com/ghostty-org/ghostty/blob/main/macos/Assets.xcassets/Alternate%20Icons/GlassImage.imageset/macOS-AppIcon-1024px.png?raw=true" alt="Glass icon" width="75" height="75" /> |
+|`holographic` |<img src="https://github.com/ghostty-org/ghostty/blob/main/macos/Assets.xcassets/Alternate%20Icons/HolographicImage.imageset/macOS-AppIcon-1024px.png?raw=true" alt="Holographic icon" width="75" height="75" /> |
+|`paper` |<img src="https://github.com/ghostty-org/ghostty/blob/main/macos/Assets.xcassets/Alternate%20Icons/PaperImage.imageset/macOS-AppIcon-1024px.png?raw=true" alt="Paper icon" width="75" height="75" /> |
+|`retro` |<img src="https://github.com/ghostty-org/ghostty/blob/main/macos/Assets.xcassets/Alternate%20Icons/RetroImage.imageset/macOS-AppIcon-1024px.png?raw=true" alt="Retro icon" width="75" height="75" /> |
+|`xray` |<img src="https://github.com/ghostty-org/ghostty/blob/main/macos/Assets.xcassets/Alternate%20Icons/XrayImage.imageset/macOS-AppIcon-1024px.png?raw=true" alt="Xray icon" width="75" height="75" /> |
+|`custom-style` | Use the official Ghostty icon but with custom styles applied to various layers. The custom styles must be specified using the additional `macos-icon`-prefixed configurations. The `macos-icon-ghost-color` and `macos-icon-screen-color` configurations are required for this style. |
+
 <Warning>
  The `custom-style` option is _experimental_. We may change
 the format of the custom styles in the future. We're still finalizing
@@ -2113,6 +2126,13 @@ Valid values:
  * `beige` - A classic 90's computer beige frame.
  * `plastic` - A glossy, dark plastic frame.
  * `chrome` - A shiny chrome frame.
+
+|Configuration Value|Frame|
+|----|----|
+|`aluminum`|<img src="https://github.com/ghostty-org/ghostty/blob/main/macos/Assets.xcassets/Custom%20Icon/CustomIconBaseAluminum.imageset/base.png?raw=true" alt="Aluminum Frame" width="75" height="75" />|
+|`beige`|<img src="https://github.com/ghostty-org/ghostty/blob/main/macos/Assets.xcassets/Custom%20Icon/CustomIconBaseBeige.imageset/beige.png?raw=true" alt="Beige Frame" width="75" height="75" />|
+|`plastic`|<img src="https://github.com/ghostty-org/ghostty/blob/main/macos/Assets.xcassets/Custom%20Icon/CustomIconBasePlastic.imageset/plastic.png?raw=true" alt="Plastic Frame" width="75" height="75" />|
+|`chrome`|<img src="https://github.com/ghostty-org/ghostty/blob/main/macos/Assets.xcassets/Custom%20Icon/CustomIconBaseChrome.imageset/chrome.png?raw=true" alt="Chrome Frame" width="75" height="75" />|
 
 This only has an effect when `macos-icon` is set to `custom-style`.
 
@@ -2387,4 +2407,3 @@ Changing this configuration requires a full restart of
 Ghostty to take effect.
 
 This only works on macOS since only macOS has an auto-update feature.
-

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,20 +2,31 @@
 const nextConfig = {
   reactStrictMode: true,
   env: {
-    GIT_COMMIT_REF: process.env.VERCEL_GIT_COMMIT_REF || '',
+    GIT_COMMIT_REF: process.env.VERCEL_GIT_COMMIT_REF || "",
+  },
+
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "github.com",
+        port: "",
+        pathname: "/ghostty/blob/main/macos/**",
+      },
+    ],
   },
 
   async headers() {
     const headers = [];
-    if (process.env.VERCEL_ENV !== 'production') {
+    if (process.env.VERCEL_ENV !== "production") {
       headers.push({
         headers: [
           {
-            key: 'X-Robots-Tag',
-            value: 'noindex',
+            key: "X-Robots-Tag",
+            value: "noindex",
           },
         ],
-        source: '/:path*',
+        source: "/:path*",
       });
     }
 


### PR DESCRIPTION
This is a naive implementation of option 1 in the discussion: [8457](https://github.com/ghostty-org/ghostty/discussions/8457)