### PR TITLE
Fix undo-timeout default in 1.2.0 release notes

### DIFF
--- a/docs/install/release-notes/1-2-0.mdx
+++ b/docs/install/release-notes/1-2-0.mdx
@@ -494,7 +494,7 @@ This includes closing a split, closing a tab, closing a window, closing
 all windows, closing other tabs, etc.
 
 Undo/redo works by keeping recently closed terminals running but hidden
-for a configurable amount of time (by default 10 seconds). During this time,
+for a configurable amount of time (by default 5 seconds). During this time,
 you can undo the close and the terminal will be reopened in the same location
 as before. Since the terminal was always running, your exact terminal state
 is restored.


### PR DESCRIPTION
The release notes say 10 seconds, the config reference and code both say 5.