### PR TITLE
add missing build dependency `blueprint-compiler` on Fedora

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -213,7 +213,8 @@ sudo dnf install \
   gtk4-layer-shell-devel \
   zig \
   libadwaita-devel \
-  gettext
+  gettext \
+  blueprint-compiler
 ```
 
 On Fedora Atomic variants, use


### PR DESCRIPTION
When trying to build v1.2.0 on Fedora, I encountered a build error
```console
❯ zig build -p $HOME/.local -Doptimize=ReleaseFast
install
└─ install ghostty
   └─ zig build-exe ghostty ReleaseFast native
      └─ run glib-compile-resources (ghostty_resources.c)
         └─ run generate_gresource_xml
            └─ run gtk_blueprint_compiler (1.5/inspector-window.ui) failure
`blueprint-compiler` not found.

Ghostty requires version 0.16.0 or newer of
`blueprint-compiler` as a build-time dependency starting
from version 1.2. Please install it, ensure that it is
available on your PATH, and then retry building Ghostty.
error: the following command exited with error code 1:
/home/khoa/code/ghostty/.zig-cache/o/a3adafebd3023d174f4ce3206a7dfdab/gtk_blueprint_compiler 1 5 /home/khoa/code/ghostty/.zig-cache/o/3e2572a1437b82059084df140bc5bce9/1.5/inspector-window.ui /home/khoa/code/ghostty/src/apprt/gtk/ui/1.5/inspector-window.blp
```
Installing the `blueprint-compiler` package fixes the issue.