### PR TITLE
Update Catppuccin Examples

### DIFF
--- a/docs/features/theme.mdx
+++ b/docs/features/theme.mdx
@@ -12,7 +12,7 @@ Ghostty ships with hundreds of built-in themes that can be selected
 with one line of configuration by using the [`theme` configuration option](/docs/config/reference#theme). For example, to use the popular Catppucin theme:
 
 ```ini
-theme = catppuccin-frappe
+theme = Catppuccin Frappe
 ```
 
 <Tip>
@@ -44,7 +44,7 @@ also includes a preview of each theme.
 Ghostty supports specifying separate light and dark themes.
 
 ```ini
-theme = dark:catppuccin-frappe,light:catppuccin-latte
+theme = dark:Catppuccin Frappe,light:Catppuccin Latte
 ```
 
 When separate light and dark themes are specified, Ghostty will


### PR DESCRIPTION
The new resource names for the Catppuccin theme should be used in the documentation about theming.

Resolve #368