### PR TITLE
docs: add lacking version information

### DIFF
--- a/docs/config/reference.mdx
+++ b/docs/config/reference.mdx
@@ -2217,6 +2217,8 @@ from the first by a comma (`,`). Percentage and pixel sizes can be mixed
 together: for instance, a size of `50%,500px` for a top-positioned quick
 terminal would be half a screen tall, and 500 pixels wide.
 
+Available since: 1.2.0
+
 ## `gtk-quick-terminal-layer`
 
 The layer of the quick terminal window. The higher the layer,


### PR DESCRIPTION
According to release note (https://ghostty.org/docs/install/release-notes/1-2-0#quick-terminal-size),  `quick-terminal-size` option is available since 1.2.0