### PR TITLE
macos-dock-drop-behaviour change reference to window which is accepted (new-window fails)

### DIFF
--- a/docs/config/reference.mdx
+++ b/docs/config/reference.mdx
@@ -2804,7 +2804,7 @@ Valid values are:
 
   * `new-tab` - Create a new tab in the current window, or open
     a new window if none exist.
-  * `new-window` - Create a new window unconditionally.
+  * `window` - Create a new window unconditionally.
 
 The default value is `new-tab`.
 


### PR DESCRIPTION
Changes the reference option for macos-dock-drop-behavior to window instead of new-window. 

new-window is rejected but window works