### PR TITLE
Update keybindings source code reference link

### DIFF
--- a/docs/config/keybind/index.mdx
+++ b/docs/config/keybind/index.mdx
@@ -34,7 +34,7 @@ For example, `a`, `ctrl+a`, `ctrl+shift+a`, `ctrl+alt+a` are
 all valid triggers.
 
 The set of possible keys is currently only available for
-reference by [viewing the source code](https://github.com/ghostty-org/ghostty/blob/d6e76858164d52cff460fedc61ddf2e560912d71/src/input/key.zig#L255).
+reference by [viewing the source code](https://github.com/ghostty-org/ghostty/blob/485b6b73bf8007dee396ca515c5b45cddfc2f5d3/src/input/key.zig#L260).
 This list is derived from Chromium's keycodes and is closely
 associated with keys that have associated USB HID codes.
 


### PR DESCRIPTION
The previous link was a pre-1.2 permalink which is no longer relevant after the [keybinding rework](https://ghostty.org/docs/install/release-notes/1-2-0#key-binding-rework) done.

This will PR will point to the new impl.