### PR TITLE
Add blueprint-compiler to installation instructions

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -213,6 +213,7 @@ sudo dnf install \
   gtk4-layer-shell-devel \
   zig \
   libadwaita-devel \
+  blueprint-compiler \
   gettext
 ```
 


### PR DESCRIPTION
on a fresh install of fedora42, `blueprint-compiler` was missing :+1: 