### PR TITLE
docs: Update Ubuntu install instructions for Ghostty

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -237,13 +237,10 @@ rpm-ostree install ghostty
 ### Ubuntu
 
 An Ubuntu package (.deb) is available from
-[ghostty-ubuntu](https://github.com/mkasberg/ghostty-ubuntu) on GitHub. After
-downloading the .deb for your Ubuntu version from the
-[Releases](https://github.com/mkasberg/ghostty-ubuntu/releases) page, install it
-as below:
+[ghostty-ubuntu](https://github.com/mkasberg/ghostty-ubuntu) on GitHub. You can install it using the following command:
 
 ```sh
-sudo apt install ./ghostty_*.deb
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/mkasberg/ghostty-ubuntu/HEAD/install.sh)"
 ```
 
 <Warning>


### PR DESCRIPTION
The Upsteam project updated the installation Process to just a script file. This simplifies the installation process for Ubuntu users.