### PR TITLE
Fix: Headers with same name break the sidecar behavior

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -140,7 +140,7 @@ use them for development.
 
 ## Linux
 
-### Dependencies
+### Linux Dependencies
 
 On Linux, you'll need to install header packages for Ghostty's dependencies
 before building it. Only a few dependencies are needed for source builds
@@ -344,7 +344,7 @@ Ghostty can be built reliably.
 
 ## macOS
 
-### Dependencies
+### macOS Dependencies
 
 #### Xcode
 
@@ -368,7 +368,7 @@ is installed.
 Next, make sure you have both the macOS and iOS SDKs installed (from
 inside Xcode → Settings → Components).
 
-#### Other Dependencies
+#### Other macOS Dependencies
 
 Ghostty also requires some additional library dependencies to be
 installed. You can choose to install them however you'd like, but


### PR DESCRIPTION
Hi Mitchell,

I found a weird bug in the `sidecar` component. It seems that if we don't use unique headers, the code gets confused and starts duplicating the items in the sidecar.

Here is a video demonstrating the issue. Look how `Dependencies` is being duplicated every time it gets highlighted.

https://github.com/user-attachments/assets/c0295240-4618-491f-a0ec-8a6cd9ea8897

I know that in Markdown [we should have unique headers](https://github.com/DavidAnson/markdownlint/blob/main/doc/md024.md):

> Rationale: Some Markdown parsers generate anchors for headings based on the heading name; headings with the same content can cause problems with that.

I tried changing the headers to be unique and that solved the issue.

https://github.com/user-attachments/assets/05668155-dddd-458e-b2b0-d336179b2a30

I think changing the mdx files to use unique headers is better than twisting the code to work in this weird case.

I haven't checked the other markdown files, but if I find any that has the same issue, I will fix it and add the changes here.

Edit: It seems that #383 solved the issue. I will close the PR.
