### PR TITLE
Update ghostty tip requirement of zig to be 0.15.2 (from 0.15.1)

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -40,7 +40,7 @@ The Zig version that each Ghostty version requires is as follows:
 | 1.0.x           | 0.13.0      |
 | 1.1.x           | 0.13.0      |
 | 1.2.x           | 0.14.1      |
-| tip             | 0.15.1      |
+| tip             | 0.15.2      |
 
 The official build environment is defined by [Nix](https://nixos.org/).
 You do not need to use Nix to build Ghostty, but the Nix environment is the


### PR DESCRIPTION
Since Oct 15 that ghostty tip depends on zig 0.15.2, not 0.15.1.