### PR TITLE
fix(sidecar): now properly highlighting selected heading on click

### DIFF
--- a/src/components/jumplink-header/JumplinkHeader.module.css
+++ b/src/components/jumplink-header/JumplinkHeader.module.css
@@ -51,6 +51,7 @@
   }
 
   & + .jumplinkHeader {
+    scroll-margin-top: calc(var(--header-height) + 16px);
     & .content {
       margin-top: 0;
     }


### PR DESCRIPTION
Closes #390

Based on the issue, it looks as though the headers are cut off at the top, which means that the IntersectionObserver was detecting the wrong heading, as the one clicked was "out of view"

A little bit of extra padding on the tops of the headings should do the trick!

Before:
[Screencast_20251114_162044.webm](https://github.com/user-attachments/assets/a7e562c0-7229-4123-b723-aa4513789914)

After:
[Screencast_20251114_162148.webm](https://github.com/user-attachments/assets/c9f19357-7b1f-4f15-b2c7-c594742992b5)
