### PR TITLE
added missing blueprint-compiler dependency

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -153,6 +153,7 @@ Required dependencies:
 - `gtk4-layer-shell`
 - `pkg-config` or `pkgconf`
 - `gettext`
+- `blueprint-compiler`
 
 <Important>
 
@@ -214,6 +215,7 @@ sudo dnf install \
   gtk4-layer-shell-devel \
   zig \
   libadwaita-devel \
+  blueprint-compiler \
   gettext
 ```
 


### PR DESCRIPTION
I tried to compile ghostty v1.2.3 for Fedora 43 an had to install `blueprint-compiler` as an additional dependency. Perphaps this is missing for other distributions too.