### PR TITLE
Add blueprint-compiler as build dependency in Debian/Ubuntu

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -198,7 +198,8 @@ sudo apt install \
   libgtk4-layer-shell-dev \
   libadwaita-1-dev \
   gettext \
-  libxml2-utils
+  libxml2-utils \
+  blueprint-compiler
 ```
 
 On Debian unstable/testing, the `gcc-multilib` package is also required


### PR DESCRIPTION
Tested it out as part of asdf-ghostty plugin CI fixes. In Ubuntu 24.04 you need to install it with `snap` though, but I'm not sure if these details need to be carried too much into the ghostty docs.