### PR TITLE
docs: Add `blueprint-compiler` as Fedora dependencies

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -212,6 +212,7 @@ On Fedora variants, use
 sudo dnf install \
   gtk4-devel \
   gtk4-layer-shell-devel \
+  blueprint-compiler \
   zig \
   libadwaita-devel \
   gettext
@@ -223,6 +224,7 @@ On Fedora Atomic variants, use
 rpm-ostree install \
   gtk4-devel \
   gtk4-layer-shell-devel \
+  blueprint-compiler \
   zig \
   libadwaita-devel \
   gettext


### PR DESCRIPTION
Closes #400 