### PR TITLE
Add sudo to dnf commands

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -203,15 +203,15 @@ These are user-maintained packages and not official Debian packages.
 Ghostty is available in [Fedora COPR](https://copr.fedorainfracloud.org/coprs/scottames/ghostty/).
 
 ```sh
-dnf copr enable scottames/ghostty
-dnf install ghostty
+sudo dnf copr enable scottames/ghostty
+sudo dnf install ghostty
 ```
 
 Ghostty is also available in [Terra](https://terra.fyralabs.com/).
 
  ```sh
- dnf install --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' terra-release
- dnf install ghostty
+ sudo dnf install --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' terra-release
+ sudo dnf install ghostty
  ```
 
 <Warning>


### PR DESCRIPTION
The `dnf` commands require elevated privileges to enable new COPR repos and to install new binaries.