### PR TITLE
chore: bump react to 19.2.3 (CVE-2025-55184, CVE-2025-67779, CVE-2025-55183)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
         "next-mdx-remote": "^5.0.0",
         "postcss-flexbugs-fixes": "^5.0.2",
         "postcss-preset-env": "^9.6.0",
-        "react": "19.2.1",
-        "react-dom": "19.2.1",
+        "react": "19.2.3",
+        "react-dom": "19.2.3",
         "react-intersection-observer": "^9.14.0",
         "rehype-highlight": "^7.0.1",
         "remark-gfm": "^4.0.0",
@@ -30,8 +30,8 @@
       "devDependencies": {
         "@types/klaw-sync": "^6.0.5",
         "@types/node": "20.14.13",
-        "@types/react": "19.2.1",
-        "@types/react-dom": "19.2.1",
+        "@types/react": "19.2.3",
+        "@types/react-dom": "19.2.3",
         "@types/xml2js": "^0.4.14",
         "eslint": "^8",
         "eslint-config-next": "15.5.7",
@@ -2342,18 +2342,18 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.1.tgz",
-      "integrity": "sha512-1U5NQWh/GylZQ50ZMnnPjkYHEaGhg6t5i/KI0LDDh3t4E3h3T3vzm+GLY2BRzMfIjSBwzm6tginoZl5z0O/qsA==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.3.tgz",
+      "integrity": "sha512-k5dJVszUiNr1DSe8Cs+knKR6IrqhqdhpUwzqhkS8ecQTSf3THNtbfIp/umqHMpX2bv+9dkx3fwDv/86LcSfvSg==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.1.tgz",
-      "integrity": "sha512-/EEvYBdT3BflCWvTMO7YkYBHVE9Ci6XdqZciZANQgKpaiDRGOLIlRo91jbTNRQjgPFWVaRxcYc0luVNFitz57A==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -8626,24 +8626,24 @@
       ]
     },
     "node_modules/react": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
-      "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
+      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
-      "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.1"
+        "react": "^19.2.3"
       }
     },
     "node_modules/react-intersection-observer": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "next-mdx-remote": "^5.0.0",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-preset-env": "^9.6.0",
-    "react": "19.2.1",
-    "react-dom": "19.2.1",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
     "react-intersection-observer": "^9.14.0",
     "rehype-highlight": "^7.0.1",
     "remark-gfm": "^4.0.0",
@@ -31,8 +31,8 @@
   "devDependencies": {
     "@types/klaw-sync": "^6.0.5",
     "@types/node": "20.14.13",
-    "@types/react": "19.2.1",
-    "@types/react-dom": "19.2.1",
+    "@types/react": "19.2.3",
+    "@types/react-dom": "19.2.3",
     "@types/xml2js": "^0.4.14",
     "eslint": "^8",
     "eslint-config-next": "15.5.7",
@@ -40,7 +40,7 @@
     "typescript": "5.5.4"
   },
   "overrides": {
-    "@types/react": "19.2.1",
-    "@types/react-dom": "19.2.1"
+    "@types/react": "19.2.3",
+    "@types/react-dom": "19.2.3"
   }
 }


### PR DESCRIPTION
## Summary
- Bump React and React-DOM from 19.2.1 to 19.2.3
- Update TypeScript types to match

## Security
Addresses React Server Components vulnerabilities disclosed on December 11, 2025:
- CVE-2025-55184 - Denial of Service (High, CVSS 7.5)
- CVE-2025-67779 - Denial of Service (High, CVSS 7.5)
- CVE-2025-55183 - Source Code Exposure (Medium, CVSS 5.3)

Reference: https://react.dev/blog/2025/12/11/denial-of-service-and-source-code-exposure-in-react-server-components

## Test plan
- [x] `npm install` succeeds
- [x] `npm run build` succeeds
- [x] `npm run lint` passes