### PR TITLE
docs: bell border feature is available on macOS

### DIFF
--- a/docs/config/reference.mdx
+++ b/docs/config/reference.mdx
@@ -2621,8 +2621,6 @@ Valid values are:
    Display a border around the alerted surface until the terminal is
    re-focused or interacted with (such as on keyboard input).
 
-   GTK only.
-
 Example: `audio`, `no-audio`, `system`, `no-system`
 
 Available since: 1.2.0


### PR DESCRIPTION
As of commit fe55d90 and PR #8768 this feature is also available on macOS.

This PR updates the documentation to reflect that change.