### PR TITLE
install: rewrite and reorganize

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -5,10 +5,14 @@ description: |-
   and running a prebuilt binary or package.
 ---
 
-The Ghostty project only officially provides prebuilt binaries
-for macOS. Other platforms may provide packages for Ghostty,
-but those packages are not officially maintained by the Ghostty project.
-This page will list both official and community-provided binary packages.
+The Ghostty project only officially distributes prebuilt binaries
+for macOS. For other platforms like Linux, we rely on a mix of distro
+maintainers and community members to build, test and distribute
+Ghostty for the wider userbase.
+
+In some cases, Ghostty maintainers may also be involved in maintaining
+packages for certain distros, but that should not be taken as endorsement
+from the Ghostty project as a whole.
 
 ## macOS
 
@@ -22,21 +26,67 @@ process as installing many typical macOS applications.
 
 ### Homebrew
 
-A [Homebrew cask](https://formulae.brew.sh/cask/ghostty) is available and maintained by the Ghostty community.
+A [Homebrew cask](https://formulae.brew.sh/cask/ghostty) is available and
+maintained by the Ghostty community. It merely repackages the official
+`.dmg` and should offer the same level of security as the official binary
+itself.
 
 ```sh
 brew install --cask ghostty
 ```
 
-## Linux (Official)
+### Nix (macOS binary)
 
-Pre-built Linux binaries are packaged by distributions and not the
-Ghostty project. The packages listed in this section are all official
-packages provided by the respective distributions.
-[Community-built packages](#linux-(community)) are also available. See
-the warning associated with those packages for more information.
+In Nixpkgs, Ghostty is available as a repackaging of the official `.dmg`
+under the package name `ghostty-bin`, not to be confused with `ghostty`,
+which is the GTK app [available for Nix on Linux](#nix).
 
-If your platform isn't available, you must
+<Note>
+
+Unfortunately, Nix currently cannot compile Ghostty from source under macOS.
+
+The reason behind that is because Nixpkgs does not yet have the ecosystem
+support required for it, chief among them include Swift 6 support, free,
+automatable and reproducible xcodebuild alternatives, etc. In the future,
+we may consider merging `ghostty-bin` into `ghostty` and provide
+from-source builds for both macOS and GTK apps.
+
+</Note>
+
+nix-darwin users can install Ghostty for either the entire system or
+for a single user through the usual method:
+
+```nix
+{
+  pkgs,
+}:
+{
+  # Systemwide install
+  environment.systemPackages = [
+    pkgs.ghostty-bin
+  ];
+  
+  # Install for a specific user
+  users.users.somebody.packages = [
+    pkgs.ghostty-bin
+  ];
+}
+```
+
+## Linux
+
+Ghostty is available in the default repositories for many Linux distributions.
+These packages are all built, tested and verified by the distributions
+themselves, and are unaffiliated with the Ghostty project.
+
+If you need help with installing and running Ghostty on a specific distribution
+or have any packaging-related questions, **please contact the maintainers of
+the Ghostty package within your own distribution** — once they've identified
+the issue to be within Ghostty itself, they will file an issue on your behalf.
+
+If your distribution isn't listed here, then please check out the
+[community-built binary packages](#linux-(community-binaries)) and see if
+there's any that you could install — otherwise, you must
 [build Ghostty from source](/docs/install/build).
 
 <Tip>
@@ -65,16 +115,9 @@ in Arch Linux's `[extra]` repository.
 pacman -S ghostty
 ```
 
-Additionally, a recipe for building and installing the tip of the `main`
-branch from source is available in the Arch User Repository (AUR) as
-[ghostty-git](https://aur.archlinux.org/packages/ghostty-git).
-Installation may be done with an AUR helper or from source per the
-[usual AUR instructions](https://wiki.archlinux.org/title/Arch_User_Repository#Installing_and_upgrading_packages).
-
-```sh
-# Install Ghostty git
-yay -S ghostty-git
-```
+Additionally, prerelease builds are also available on the AUR
+under `ghostty-git`. See the ["Prerelease Builds"](/docs/install/pre#aur)
+for specific details.
 
 ### Gentoo
 
@@ -84,70 +127,89 @@ Ghostty is available in the official Gentoo repository.
 emerge -av ghostty
 ```
 
-### NixOS
+### Nix
 
-Ghostty is available in [nixpkgs](https://search.nixos.org/packages?from=0&size=50&sort=relevance&type=packages&query=ghostty).
+On Linux, Ghostty can be installed with Nix in two major ways: by either using
+the `ghostty` package from [Nixpkgs] (maintained by a team of Nixpkgs maintainers)
+or the Flake available from Ghostty's source repository, maintained directly
+by the Ghostty project.
 
-```
-environment.systemPackages = [
-  pkgs.ghostty
-];
-```
+The package on Nixpkgs is the simplest option for most regular users, while
+the Flake allows more advanced users to install pinned versions of the
+development branch ("tip releases") in order to access more bleeding-edge
+features. As such, this page **only covers the package in Nixpkgs** — information
+regarding the Flake can be found in [its own section](/docs/install/pre#nix-flake)
+on the "Prereleases Builds" page.
 
-### Nix Flake
+[Nixpkgs]: https://search.nixos.org/packages?from=0&size=50&sort=relevance&type=packages&query=ghostty
 
-There is Nix package that can be used in the
-[Ghostty flake](https://github.com/ghostty-org/ghostty/blob/main/flake.nix)
-(`packages.ghostty` or `packages.default`). This is a good way
-to track specific commits of Ghostty.
+<Note>
 
-While the Ghostty project does not maintain any official packages for
-Linux, Ghostty maintains an in-repo Nix flake because Nix is used as
-our primary development and CI environment. The Ghostty project does
-not maintain any official NixOS packages (in `nixpkgs`).
+The `ghostty` package on Nixpkgs should not be confused with
+[`ghostty-bin`](#nix-(macos-binary)), which is a repackaging of the
+official `.dmg` for use on macOS.
 
-Below is an example:
+</Note>
+
+#### NixOS
+
+NixOS users can install Ghostty on an entire system or
+just for a single user through the usual method:
 
 ```nix
 {
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-
-    ghostty = {
-      url = "github:ghostty-org/ghostty";
-    };
-  };
-
-  outputs = {
-    nixpkgs,
-    ghostty,
-    ...
-  }: {
-    nixosConfigurations.mysystem = nixpkgs.lib.nixosSystem {
-      modules = [
-        ({ pkgs, ... }: {
-          environment.systemPackages = [
-            ghostty.packages.${pkgs.stdenv.hostPlatform.system}.default
-          ];
-        })
-      ];
-    };
-  };
+  pkgs,
+}:
+{
+  # Systemwide install
+  environment.systemPackages = [
+    pkgs.ghostty
+  ];
+  
+  # Install for a specific user
+  users.users.somebody.packages = [
+    pkgs.ghostty
+  ];
 }
 ```
 
-<Note>
-This isn't an official package in Nixpkgs but it is officially maintained
-by the Ghostty project so we put it in the "official" section.
-</Note>
+Trying out Ghostty without installing it with `nix run` or `nix-shell`
+should also work just fine:
+
+```sh
+nix run nixpkgs#ghostty
+nix-shell -p ghostty --run ghostty
+```
+
+#### Nix on other distros
+
+<Warning>
+
+Running Ghostty with Nix on non-NixOS systems will **fail to launch**
+without extra setup. This is because graphical programs compiled for Nixpkgs
+expect OpenGL drivers to be located in a different location than traditional
+distros, and will fail to find them if not manually worked around.
+
+</Warning>
+
+There are multiple ways to fix this, either by running Ghostty with a
+wrapper program like [`nixGL`] or [`nix-gl-host`] that sets up the correct
+OpenGL driver paths, or use a more permanent solution like
+[`nix-system-graphics`].
+
+[`nixGL`]: https://github.com/nix-community/nixGL
+[`nix-gl-host`]: https://github.com/numtide/nix-gl-host
+[`nix-system-graphics`]: https://github.com/soupglasses/nix-system-graphics
+
+Other than that, instructions are nearly identical to NixOS.
 
 
 ### openSUSE
 
 openSUSE has [dropped][opensuse-dropped] Ghostty from its official repositories
-as it does not allow packages to depend on a specific version of Zig, which is
-*critical* for Ghostty as nearly all new Zig releases introduce breaking changes
-that prevent software written for a previous Zig version from compiling.
+as it does not allow packages to depend on a specific version of Zig. This is a
+*crucial* issue for Ghostty, as nearly all new Zig releases introduce breaking
+changes, preventing software targeting a previous Zig version to be compiled.
 
 [opensuse-dropped]: https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/BMZTZ2DCNWXARP5UD7MECR6PCWOTKR5G/#BMZTZ2DCNWXARP5UD7MECR6PCWOTKR5G
 
@@ -163,10 +225,11 @@ snap install ghostty --classic
 ```
 
 <Note>
-The Snap package at Snapcraft has an external maintainer but the build
-process is triggered by official scripts in the Ghostty repository and
-the package will be transferred to the Ghostty organization in the future,
-probably coinciding with future Ghostty 1.2 release.
+While the Snap at Snapcraft is currently maintained by an external maintainer,
+the Snap itself is built using Ghostty's own scripts, and we ensure that the
+Snap builds as a part of our CI regimen. We are currently working on formally
+transferring the Snap to the Ghostty project and making it one of the
+officially supported and distributed package formats for Linux.
 </Note>
 
 ### Solus
@@ -185,22 +248,38 @@ Ghostty is available in the official package repository.
 xbps-install ghostty
 ```
 
-## Linux (Community)
+## Linux (Community Binaries)
 
 The packages in this section provide binary installs for Ghostty but
-are not official packages within the associated distributions. These
-packages are maintained by community members and as such a higher level
-of caution should be taken when installing them.
+are not official packages within the associated distributions.
+
+<Warning>
+
+Community binaries carry a much higher risk compared to builds
+directly from the Ghostty project or from distro maintainers, since
+they have been compiled beforehand on a computer that might not be held
+to the same security standards as a package compiled by the Ghostty
+project or by distro maintainers.
+
+In case that was unclear, **by installing these packages, you implicitly
+accept the risk of a third party that could potentially temper with the
+binary files for malicious purposes**.
+
+Security concerns aside, there may also be silent breakages, depending on the
+architectural differences between your computer and the computer that built the
+binary package, or the compile flags used in the build process.
+
+Overall, if you are fine with these risks, feel free to use these community
+builds. Otherwise, [compiling from source](/docs/install/build) is the much
+safer option.
+
+</Warning>
 
 ### Debian
 
 Ghostty is available in [this community-maintained repository](https://debian.griffo.io/).
 
-Build, packaging and instructions for each version are available in the README of the [repository](https://github.com/dariogriffo/ghostty-debian)
-
-<Warning>
-These are user-maintained packages and not official Debian packages.
-</Warning>
+Build, packaging and instructions for each version are available in the README of the [repository](https://github.com/dariogriffo/ghostty-debian).
 
 ### Fedora
 
@@ -217,10 +296,6 @@ Ghostty is also available in [Terra](https://terra.fyralabs.com/).
  dnf install --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' terra-release
  dnf install ghostty
  ```
-
-<Warning>
-These are user-maintained packages and not official Fedora packages.
-</Warning>
 
 #### Atomic Desktops (Silverblue)
 
@@ -247,10 +322,6 @@ An Ubuntu package (.deb) is available from
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/mkasberg/ghostty-ubuntu/HEAD/install.sh)"
 ```
 
-<Warning>
-This is a user-maintained package. It is not an official Ubuntu package.
-</Warning>
-
 ### Universal AppImage
 
 Ghostty is available as a Universal AppImage which is compatible with any Linux distribution (Including musl based).
@@ -266,6 +337,3 @@ chmod a+x Ghostty-${VERSION}-${ARCH}.appimage
 
 For comprehensive installation instructions, please refer the [installation guide](https://github.com/pkgforge-dev/ghostty-appimage#%EF%B8%8F-installation).
 
-<Warning>
-This is a community-maintained AppImage. It is not an official AppImage.
-</Warning>

--- a/docs/install/pre.mdx
+++ b/docs/install/pre.mdx
@@ -25,8 +25,9 @@ with more details in the sections following the table.
 | Platform | Description |
 | -------- | ----------- |
 | macOS | `auto-update-channel` to get the latest prerelease builds |
-| Nix   | Standard `flake.nix` in the Ghostty repository |
-| Linux | [Build from source](/docs/install/build) |
+| Arch Linux | `ghostty-git` on the AUR |
+| NixOS/Nix on other distros | Flake within the Ghostty repository |
+| Other Linux distros | [Build from source](/docs/install/build) |
 
 ## macOS
 
@@ -76,19 +77,91 @@ This is community-maintained. The `auto-update-channel` setting
 is an official distribution channel.
 </Warning>
 
-## Nix
+## Linux
 
-For Nix users on Linux, there is a standard
-[`flake.nix` in the Ghostty repository](https://github.com/ghostty-org/ghostty/blob/main/flake.nix).
-Follow the same instructions as the
-[Nix Flake](/docs/install/build#building-with-nix)
-section on the building from source page.
+### AUR
+
+<Warning>
+
+The AUR package is community-maintained. Any issues regarding packaging
+or the build process should be reported to the AUR maintainer first,
+and then to the Ghostty project.
+
+</Warning>
+
+The [`ghostty-git`] package on the Arch User Repository (AUR) provides
+a way to automatically build and install the latest prerelease version
+of Ghostty with ease.
+
+[`ghostty-git`]: https://aur.archlinux.org/packages/ghostty-git
+
+Installation may be done with an AUR helper or from source per the
+[usual AUR instructions](https://wiki.archlinux.org/title/Arch_User_Repository#Installing_and_upgrading_packages).
+
+```sh
+# Install Ghostty git
+yay -S ghostty-git
+```
+
+### Nix Flake
+
+The Ghostty repository comes with a Flake that can be used to build, run
+and install development ("tip") versions of Ghostty reproducibly, which
+is directly used, tested and maintained by Ghostty maintainers as our
+primary development and CI environment.
+
+```sh
+# Build and run the latest tip version of Ghostty without installing
+nix run github:ghostty-org/ghostty
+```
 
 <Note>
-**The package in the flake only supports Linux.** Building macOS app
-bundles is not well supported by Nix, so the package in the flake
-only supports Linux. If you want to contribute a macOS package to
-the flake, feel free to make a pull request!
+
+The Flake currently does not support macOS builds due to limitations of
+the Nix ecosystem. See the [Nix (macOS binary)](/docs/install/binary#nix-(macos-binary))
+section of the "Prebuilt Binaries and Packages" page for more details.
+
 </Note>
 
+<Warning>
+
+If you are installing the Flake on a non-NixOS system, be sure to read
+the [important caveats](/docs/install/binary#nix-on-other-distros) regarding
+running OpenGL programs built with Nix on non-NixOS systems. Ghostty will
+likely **fail to launch** without the workarounds described there.
+
+</Warning>
+
+NixOS users can install Ghostty either directly as a package under
+`packages.<system>.default` (where `<system>` is your current host system,
+e.g. `x86_64-linux`), or use the overlay at `overlays.default`.
+
+```nix
+{
+  pkgs,
+  inputs,
+}:
+{
+  # Installing the package directly
+  users.users.somebody.packages = [
+    inputs.ghostty.${pkgs.stdenv.hostPlatform.system}.default
+  ];
+
+  # Alternatively, using overlays:
+  nixpkgs.overlays = [
+    inputs.ghostty.overlays.default
+  ];
+  users.users.somebody.packages = [
+    pkgs.ghostty
+  ];
+}
+```
+
+The Flake also exposes Ghostty compiled under different optimization settings,
+including `ghostty-debug`, `ghostty-releasefast` and `ghostty-releasesafe`:
+`releasefast` is the default; `debug` enables better debug information at the
+cost of performance; and `releasesafe` is rarely used.
+
+`debug` and `releasefast` are also available as overlays, under `overlays.debug`
+and `overlays.releasefast` respectively.
 

--- a/src/pages/download/release.tsx
+++ b/src/pages/download/release.tsx
@@ -38,7 +38,7 @@ export default function ReleaseDownloadPage({
         <div className={s.linuxLinks}>
           <ButtonLink
             size="large"
-            href="/docs/install/binary#linux-(official)"
+            href="/docs/install/binary#linux"
             text="Package Manager"
             icon={<Package strokeWidth={2} size={18} />}
             showExternalIcon={false}


### PR DESCRIPTION
This is a biggie.

The way we used the word "official" was incredibly nebulous and unclear to the average person to the point that I felt driven to rewrite the entire page. Now, we only use the word "official" to mean packages built and distributed by the Ghostty project itself, while trustworthy packages built by e.g. Linux distros are explicitly named as such.

A whole laundry list of changes:

- Added the `ghostty-bin` package on Nixpkgs under macOS, plus an explanation of why we can't build Ghostty from source there

- Clarified that the Homebrew Cask and the `ghostty-bin` Nix package are merely repackagings of the `.dmg`, and should be perfectly safe and trustworthy

- Renamed the "Linux (Official)" section to just "Linux", and the "Linux (Community)" section to "Linux (Community Binaries)"

- Moved the instructions for using the AUR and the Nix flake to the "Prerelease Builds" page. That is the more logical place for them anyways, since an end user likely only uses them for building and installing tip releases

- Added much more detailed instructions on how to use the Flake (you can't trust people to magically know this)

- Added important caveats when it comes to running 3D-accelerated programs built with Nix on non-NixOS systems. It is so painfully common for people to install Ghostty on Nix on e.g. Fedora and then complain about how Ghostty fails to run there.

- Added a much longer warning to using community binaries. For the sake of safety.

- Fixed the links pointing to the Binary Releases page. If there's any I missed, let me know that I screwed up

- Removed openSUSE (done in a separate commit so that if they ever un-drop us, we could simply revert the commit)