### PR TITLE
change title/description to actual action

### DIFF
--- a/docs/vt/osc/11x.mdx
+++ b/docs/vt/osc/11x.mdx
@@ -1,6 +1,6 @@
 ---
-title: Query or Change Dynamic Colors (OSC 110–119)
-description: Query or change dynamic colors based on their indices.
+title: Reset Dynamic Colors (OSC 110–119)
+description: Reset dynamic colors based on their indices.
 ---
 
 <VTSequence sequence={["OSC", "Pn", "ST"]} />


### PR DESCRIPTION
This was probably copied from the 1x.mdx file without fully updating title and description. The index on the left in the documentation has the correct name, so that doesn't seem to be automatically extracted from the title of this file.