### PR TITLE
For slow startup, suggest +new-window too

### DIFF
--- a/docs/help/index.mdx
+++ b/docs/help/index.mdx
@@ -12,14 +12,14 @@ we try to document as many common issues and solutions as possible.
 
 ## Common Issues and Solutions
 
-| Issue                                                                      | Solution                                                    |
-| -------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| Error "missing or unsuitable terminal" when running commands or using SSH. | [Terminfo](/docs/help/terminfo)                             |
-| macOS window managers such as Yabai or Aerospace act strange               | [macOS Tiling Window Managers](/docs/help/macos-tiling-wms) |
-| Ghostty has slow startup or high memory usage on Linux.                    | [GTK Single Instance](/docs/help/gtk-single-instance)       |
-| "Unable to acquire OpenGL context" error on Linux                          | [GTK OpenGL Context](/docs/help/gtk-opengl-context)         |
-| macOS defaults to login shells                                             | [macOS Login Shells](/docs/help/macos-login-shells)         |
-| CLI tools like Claude Code, Docker, etc. repeatedly flash or flicker       | [Synchronized Output](/docs/help/synchronized-output)       |
+| Issue                                                                      | Solution                                                                                                       |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Error "missing or unsuitable terminal" when running commands or using SSH. | [Terminfo](/docs/help/terminfo)                                                                                |
+| macOS window managers such as Yabai or Aerospace act strange               | [macOS Tiling Window Managers](/docs/help/macos-tiling-wms)                                                    |
+| Ghostty has slow startup or high memory usage on Linux.                    | [GTK Single Instance](/docs/help/gtk-single-instance), [`+new-window`](https://ghostty.org/docs/linux/systemd) |
+| "Unable to acquire OpenGL context" error on Linux                          | [GTK OpenGL Context](/docs/help/gtk-opengl-context)                                                            |
+| macOS defaults to login shells                                             | [macOS Login Shells](/docs/help/macos-login-shells)                                                            |
+| CLI tools like Claude Code, Docker, etc. repeatedly flash or flicker       | [Synchronized Output](/docs/help/synchronized-output)                                                          |
 
 ## Seeking Help
 


### PR DESCRIPTION
As discussed at https://github.com/ghostty-org/ghostty/discussions/10426#discussioncomment-15584726, the current documentation points to only `--gtk-single-instance`, whereas `+new-window` seems to be the best way to get fast startup on Linux.

I don't have Node installed haven't checked how this appears. If the CI system builds artefacts I'll try to take a look. I also wasn't sure if extending the table to the right was the desired syntax.