### PR TITLE
Add `blueprint-compiler` as a dependency in Arch Linux

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -187,7 +187,8 @@ sudo pacman -S \
   gtk4 \
   gtk4-layer-shell \
   libadwaita \
-  gettext
+  gettext \
+  blueprint-compiler
 ```
 
 #### Debian and Ubuntu


### PR DESCRIPTION
I just compiled ghostty on Arch Linux and found that it is missing this dependency.