### PR TITLE
Fix typo in build instructions

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -67,7 +67,7 @@ If you intend to contribute to Ghostty, please consult the
 ["Developing Ghostty"](https://github.com/ghostty-org/ghostty/blob/main/HACKING.md)
 documents on how to build Ghostty in a development environment.
 While most of the steps are exactly the same, we will be assuming a source
-tarball-based build for now on for the sake of simplicity.
+tarball-based build from now on for the sake of simplicity.
 
 </Warning>
 


### PR DESCRIPTION
on the https://ghostty.org/docs/install/build#getting-the-source-code page:
"for now on" -> "from now on"