### PR TITLE
Update Windows support status in release notes

### DIFF
--- a/docs/install/release-notes/1-3-0.mdx
+++ b/docs/install/release-notes/1-3-0.mdx
@@ -840,7 +840,7 @@ I don't want to promise any specific features, but we're working hard
 on making Ghostty scriptable, enabling a true Tmux control mode, graphical
 preferences, and more.
 
-To answer a common request, **Windows** is still not planned.
+To answer a common request, support for **Microsoft Windows** is still not planned.
 This still remains part of the long term roadmap, but I think that focusing
 on a capable and powerful libghostty will enable better Windows support
 in the long run. libghostty itself already supports Windows.


### PR DESCRIPTION
Clarified that support for Microsoft Windows is not planned, while libghostty already supports Windows.