### PR TITLE
Be more specific about fish versions supporting OSC 133

### DIFF
--- a/docs/install/release-notes/1-3-0.mdx
+++ b/docs/install/release-notes/1-3-0.mdx
@@ -107,7 +107,7 @@ the cursor, like a normal text field.
 
 <Video src="https://web.files.ghostty.org/release-notes-1-3-0-click.mp4" />
 
-This feature is supported natively by Fish (v4+) and Nushell (0.111+).
+This feature is supported natively by Fish (4.1+) and Nushell (0.111+).
 For other shells, support varies based on Ghostty's injected shell
 integration. If you're using a supported shell, this will just magically
 work.
@@ -485,7 +485,7 @@ The following default behaviors have been changed in 1.3.0:
   running terminal by searching its title or working directory, with
   tab color indicators (macOS). GH-9945
 - Support Kitty's `click_events` extension which lets clicking the
-  prompt in supported shells move the cursor, such as Fish v4+ and Nushell
+  prompt in supported shells move the cursor, such as Fish 4.1+ and Nushell
   0.111+. GH-10536
 - Support OSC133 `cl=line` so bash and zsh get clickable prompts with the
   above. GH-10542


### PR DESCRIPTION
Ref: https://github.com/ghostty-org/ghostty/discussions/11333

Also dropped the `v` for consistency w/ nu.