### PR TITLE
fix: use double backticks for inline code containing backtick in selection-word-chars

### DIFF
--- a/docs/config/reference.mdx
+++ b/docs/config/reference.mdx
@@ -723,7 +723,7 @@ Multi-codepoint sequences (e.g. emoji) are not supported.
 The null character (U+0000) is always treated as a boundary and does not
 need to be included in this configuration.
 
-Default: ` \t'"│`|:;,()[]\{\}\<\>$`
+Default: `` \t'"│`|:;,()[]\{\}\<\>$ ``
 
 To add or remove specific characters, you can set this to a custom value.
 For example, to treat semicolons as part of words:


### PR DESCRIPTION
The default value for selection-word-chars contains a literal backtick, which broke the inline code rendering in markdown.

Before

<img width="257" height="59" alt="Screenshot 2026-03-11 at 8 34 51 PM" src="https://github.com/user-attachments/assets/9a609925-b114-43e1-af14-8e4d5d4322c2" />

After

<img width="338" height="59" alt="Screenshot 2026-03-11 at 8 35 23 PM" src="https://github.com/user-attachments/assets/235511ec-1695-4aff-961d-404594bda5e8" />
