### PR TITLE
Add Zig version for 1.3.x in documentation

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -40,6 +40,7 @@ The Zig version that each Ghostty version requires is as follows:
 | 1.0.x           | 0.13.0      |
 | 1.1.x           | 0.13.0      |
 | 1.2.x           | 0.14.1      |
+| 1.3.x           | 0.15.2      |
 | tip             | 0.15.2      |
 
 The official build environment is defined by [Nix](https://nixos.org/).


### PR DESCRIPTION
I've noticed that v1.3.x isn't listed in the table for required Zig versions (after failing to build Ghostty 1.3.0 with Zig 0.14.1); this PR adds the required version.