### PR TITLE
Fix: Have config file locations to match edit.zig (Bug #441)

### DIFF
--- a/docs/config/index.mdx
+++ b/docs/config/index.mdx
@@ -35,14 +35,18 @@ Ghostty is configured using a text-based configuration file.
 
 ### File Location
 
-The configuration file, `config`, is loaded from these locations in the following order:
+The configuration file is named `config.ghostty` (or `config` before 1.2.3),
+is loaded from these locations in the following order:
+
+#### macOS-specific Path (macOS only):
+- `$HOME/Library/Application\ Support/com.mitchellh.ghostty/config.ghostty`.
+- `$HOME/Library/Application\ Support/com.mitchellh.ghostty/config`.
+- macOS also supports the XDG configuration path mentioned below.
 
 #### XDG configuration Path (all platforms):
-- `$XDG_CONFIG_HOME/ghostty/config`.
+- `$XDG_CONFIG_HOME/ghostty/config.ghostty`
+- `$XDG_CONFIG_HOME/ghostty/config`
 - if **XDG_CONFIG_HOME** is not defined, it defaults to `$HOME/.config/ghostty/config`.
-#### macOS-specific Path (macOS only):
-- `$HOME/Library/Application\ Support/com.mitchellh.ghostty/config`.
-- macOS also supports the XDG configuration path mentioned above.
 
 If both locations exist, they are loaded in the order above
 with conflicting values in later files overriding earlier ones.


### PR DESCRIPTION
The docs, as exists, detail config file locations that doesn't match those described in the current version of edit.zig. This changes it to match.

See https://github.com/ghostty-org/website/issues/441.