### PR TITLE
docs(install): document additional arch packages

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -115,6 +115,12 @@ in Arch Linux's `[extra]` repository.
 pacman -S ghostty
 ```
 
+Ghostty's shell integration scripts and terminfo are packaged separately.
+
+```sh
+pacman -S ghostty-shell-integration ghostty-terminfo
+```
+
 Additionally, prerelease builds are also available on the AUR
 under `ghostty-git`. See the ["Prerelease Builds"](/docs/install/pre#aur)
 for specific details.


### PR DESCRIPTION
On Arch, Ghostty's shell integration scripts and terminfo are packaged separately from Ghostty itself. I documented this to prevent users from running into issues like I did, described below.

When I updated to Ghostty 1.3.0 on Arch and launched Ghostty, I received the following error.

```
Error: nu::parser::module_not_found

  × Module not found.
   ╭─[repl_entry #0:1:5]
 1 │ use ghostty *
   ·     ───┬───
   ·        ╰── module ghostty not found
   ╰────
  help: module files and their paths must be available before your script is run
        as parsing occurs before anything is evaluated
```

This was because Ghostty 1.3.0 shipped with a Nushell shell integration and my configuration was trying to use it. Since I didn't have the `ghostty-shell-integration` package installed I received the above error.