### PR TITLE
Update installation instructions for Fedora variants

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -211,6 +211,7 @@ On Fedora variants, use
 
 ```sh
 sudo dnf install \
+  blueprint-compiler \
   gtk4-devel \
   gtk4-layer-shell-devel \
   zig \
@@ -222,6 +223,7 @@ On Fedora Atomic variants, use
 
 ```sh
 rpm-ostree install \
+  blueprint-compiler \
   gtk4-devel \
   gtk4-layer-shell-devel \
   zig \


### PR DESCRIPTION
On Fedora 43 I had to specifically install this package as well.

Not sure what the package name is for other distributions and whether it's necessary there at all, so I only updated the Fedora notes.