### PR TITLE
Add example to create new tab and set title in AppleScript

### DIFF
--- a/docs/features/applescript.mdx
+++ b/docs/features/applescript.mdx
@@ -215,6 +215,24 @@ tell application "Ghostty"
 end tell
 ```
 
+### Set Tab Titles
+
+Use `perform action` with `set_tab_title` to label tabs from a script.
+
+An example of creating a new tab and setting the title:
+
+```AppleScript
+tell application "Ghostty"
+    set win to front window
+    set cfg to new surface configuration
+
+    set t1 to new tab in win with configuration cfg
+    perform action "set_tab_title:Editor" on focused terminal of t1
+    input text "nvim .\n" to focused terminal of t1
+
+end tell
+```
+
 ### Jump to a Terminal by Working Directory
 
 ```AppleScript


### PR DESCRIPTION
Adds a short example to docs that shows how to create a new tab and set the title using AppleScript.

The set_tab_title as added in: https://github.com/ghostty-org/ghostty/pull/11373

Requires Ghostty v1.3.1