### PR TITLE
Updated Ubuntu Instructions for PPA

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -315,11 +315,12 @@ rpm-ostree install ghostty
 
 ### Ubuntu
 
-An Ubuntu package (.deb) is available from
-[ghostty-ubuntu](https://github.com/mkasberg/ghostty-ubuntu) on GitHub. You can install it using the following command:
+[ghostty-ubuntu](https://github.com/mkasberg/ghostty-ubuntu) provides Ubuntu packages (.deb) and a [Launchpad PPA](https://launchpad.net/~mkasberg/+archive/ubuntu/ghostty-ubuntu). Use the following commands to add the PPA and install Ghostty:
 
 ```sh
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/mkasberg/ghostty-ubuntu/HEAD/install.sh)"
+sudo add-apt-repository ppa:mkasberg/ghostty-ubuntu
+sudo apt update
+sudo apt install ghostty
 ```
 
 ### Universal AppImage


### PR DESCRIPTION
As discussed here: https://github.com/ghostty-org/ghostty/discussions/11715

[ghostty-ubuntu](https://github.com/mkasberg/ghostty-ubuntu) recently updated the installation instructions to use a PPA. This commit updates the Ghostty website with the most recent instructions.

<img width="792" height="241" alt="Screenshot 2026-03-21 at 21-55-27" src="https://github.com/user-attachments/assets/64890679-5cfd-4091-b5d5-8e755db00b91" />
