### PR TITLE
docs: clarify the load order of macOS and XDG config files

### DIFF
--- a/docs/config/index.mdx
+++ b/docs/config/index.mdx
@@ -38,20 +38,21 @@ Ghostty is configured using a text-based configuration file.
 The configuration file is named `config.ghostty` (or `config` before 1.2.3),
 is loaded from these locations in the following order:
 
-#### macOS-specific Path (macOS only):
-- `$HOME/Library/Application\ Support/com.mitchellh.ghostty/config.ghostty`.
-- `$HOME/Library/Application\ Support/com.mitchellh.ghostty/config`.
-- macOS also supports the XDG configuration path mentioned below.
-
 #### XDG configuration Path (all platforms):
 - `$XDG_CONFIG_HOME/ghostty/config.ghostty`
 - `$XDG_CONFIG_HOME/ghostty/config`
 - if **XDG_CONFIG_HOME** is not defined, it defaults to `$HOME/.config/ghostty/config`.
 
-If both locations exist, they are loaded in the order above
-with conflicting values in later files overriding earlier ones.
+#### macOS-specific Path (macOS only):
+- `$HOME/Library/Application\ Support/com.mitchellh.ghostty/config.ghostty`.
+- `$HOME/Library/Application\ Support/com.mitchellh.ghostty/config`.
+- macOS also supports the XDG configuration path mentioned above.
+
+If both locations exist, they are loaded in the order above with
+conflicting values in later files overriding earlier ones.
 Configuration is optional and if no configuration file is found,
-Ghostty will use its defaults.
+Ghostty will use its defaults.  Note that all macOS-specific files are
+loaded *after* all XDG files.
 
 ### Syntax
 


### PR DESCRIPTION
`ghostty` loads XDG configs and then, on macOS, loads macOS configs, allowing them to override the XDG config.  The docs don't make this very clear, so I've re-ordered the lists and added an explicit note.

bug: https://github.com/ghostty-org/website/issues/449