### PR TITLE
config/index: fix XDG_CONFIG_HOME default value typo

### DIFF
--- a/docs/config/index.mdx
+++ b/docs/config/index.mdx
@@ -46,7 +46,7 @@ is loaded from these locations in the following order:
 #### XDG configuration Path (all platforms):
 - `$XDG_CONFIG_HOME/ghostty/config.ghostty`
 - `$XDG_CONFIG_HOME/ghostty/config`
-- if **XDG_CONFIG_HOME** is not defined, it defaults to `$HOME/.config/ghostty/config`.
+- if **XDG_CONFIG_HOME** is not defined, it defaults to `$HOME/.config`.
 
 If both locations exist, they are loaded in the order above
 with conflicting values in later files overriding earlier ones.


### PR DESCRIPTION
What we default is the variable, not the entire Ghostty config path.