### PR TITLE
docs: add note for LD_LIBRARY_PATH when manually building and installing ghostty with -fno-sys=gtk4-layer-shell

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -309,6 +309,16 @@ ensure that `~/.local/bin` is on your _system_ `PATH`. The desktop environment
 itself must have that path in the `PATH`. Google for your specific desktop
 environment and distribution to learn how to do that.
 
+If you built Ghostty with the `-fno-sys=gtk4-layer-shell` flag, you may
+additionally require the `LD_LIBRARY_PATH` environment variable to be set to
+`$HOME/.local/lib`. To avoid globally polluting `LD_LIBRARY_PATH` when launching
+from a desktop environment, you can simply patch the installed Ghostty elf with
+`patchelf`:
+
+```shell-session
+patchelf --set-rpath '$ORIGIN/../lib' $HOME/.local/bin/ghostty
+```
+
 For system-wide installs, we recommend `/usr` (likely requires `sudo`):
 
 ```shell-session


### PR DESCRIPTION
The following note might be helpful for local ghostty installs when `~/.local/lib` isn't in a global `LD_LIBRARY_PATH` setting and a shared library like gtk4-layer-shell was also built from source and installed there.
