### PR TITLE
docs: add Metal Toolchain to macOS build dependencies

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -366,8 +366,8 @@ xcode-select --print-path
 The above can happen if you install the Xcode Command Line Tools _after_ Xcode
 is installed.
 
-Next, make sure you have both the macOS and iOS SDKs installed (from
-inside Xcode → Settings → Components).
+Next, make sure you have the macOS SDK, iOS SDK, and Metal Toolchain
+installed (from inside Xcode → Settings → Components).
 
 #### Other Dependencies
 


### PR DESCRIPTION
When following the "Build from Source" instructions in a fresh macOS dev environment, the build initially fails due to missing Metal Toolchain.

This change documents the relevant Xcode component alongside the installation instructions for the macOS and iOS SDKs.

Bug: #452