### PR TITLE
Update Arch Linux instructions with `pkgconf` dependency

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -187,6 +187,7 @@ doas apk add \
 sudo pacman -S \
   gtk4 \
   gtk4-layer-shell \
+  pkgconf \
   libadwaita \
   gettext
 ```


### PR DESCRIPTION
Update Arch Linux instructions with [`pkgconf`](https://archlinux.org/packages/core/x86_64/pkgconf/) dependency. `pkg-config` (`pkgconf`) is already noted in the required dependencies and is mentioned on a few other distro instructions already:

https://github.com/ghostty-org/website/blob/1349209ec2cf4fdada55b3647e8e5e340266e434/docs/install/build.mdx#L150-L156

This is spawning from building Ghostty from source with a fresh [Manjaro](https://manjaro.org/) Linux (Arch-based) install in a QEMU VM:

```
$ zig build -p $HOME/.local -Doptimize=ReleaseFast
...
error: error: unable to find dynamic system library 'gtk4' using strategy 'mode_first'. searched paths:
...
error: unable to find dynamic system library 'libadwaita-1' using strategy 'mode_first'. searched paths:
...

$ which pkg-config
pkg-config not found

$ pamac install pkgconf
```

It looks like `pkgconf` is also available through [`base-devel`](https://archlinux.org/packages/core/any/base-devel/)