### PR TITLE
Correct typo in NixOS Flakes documentation

### DIFF
--- a/docs/install/pre.mdx
+++ b/docs/install/pre.mdx
@@ -144,7 +144,7 @@ e.g. `x86_64-linux`), or use the overlay at `overlays.default`.
 {
   # Installing the package directly
   users.users.somebody.packages = [
-    inputs.ghostty.${pkgs.stdenv.hostPlatform.system}.default
+    inputs.ghostty.packages.${pkgs.stdenv.hostPlatform.system}.default
   ];
 
   # Alternatively, using overlays:


### PR DESCRIPTION
The example Flake usage in the prerelease builds documentation does not refer to the correct package path.