### PR TITLE
docs/install: Update openSUSE instructions

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -206,15 +206,11 @@ Other than that, instructions are nearly identical to NixOS.
 
 ### openSUSE
 
-openSUSE has [dropped][opensuse-dropped] Ghostty from its official repositories
-as it does not allow packages to depend on a specific version of Zig. This is a
-*crucial* issue for Ghostty, as nearly all new Zig releases introduce breaking
-changes, preventing software targeting a previous Zig version to be compiled.
+Ghostty is available as [`ghostty`](https://software.opensuse.org/package/ghostty) in the official openSUSE Tumbleweed repository.
 
-[opensuse-dropped]: https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/BMZTZ2DCNWXARP5UD7MECR6PCWOTKR5G/#BMZTZ2DCNWXARP5UD7MECR6PCWOTKR5G
-
-openSUSE users should try to build Ghostty from source instead, or try
-installing Ghostty from a third-party, community-maintained repository.
+```sh
+zypper install ghostty
+```
 
 ### Snap
 


### PR DESCRIPTION
Ghostty has been brought back to openSUSE Tumbleweed repository.