### PR TITLE
Add gtk4-layer-shell-devel to installation instructions

### DIFF
--- a/docs/install/build.mdx
+++ b/docs/install/build.mdx
@@ -248,7 +248,8 @@ sudo zypper install \
   pkgconf \
   ncurses-devel \
   zig \
-  gettext
+  gettext \
+  gtk4-layer-shell-devel
 ```
 
 #### openSUSE Leap


### PR DESCRIPTION
### Resolves Build Error
The build currently fails because the system library `gtk4-layer-shell-0` is missing (tested only on opensuse idk if you need to update in other distros as well but keep up the good work :D):
```text
error: error: unable to find dynamic system library 'gtk4-layer-shell-0' using strategy 'mode_first'. searched paths:
  /usr/local/lib64/libgtk4-layer-shell-0.so
  /usr/local/lib/libgtk4-layer-shell-0.so
  /lib64/libgtk4-layer-shell-0.so
  /lib/libgtk4-layer-shell-0.so
  /usr/lib64/libgtk4-layer-shell-0.so
  /usr/lib/libgtk4-layer-shell-0.so
  /usr/local/lib64/libgtk4-layer-shell-0.a
  /usr/local/lib/libgtk4-layer-shell-0.a
  /lib64/libgtk4-layer-shell-0.a
  /lib/libgtk4-layer-shell-0.a
  /usr/lib64/libgtk4-layer-shell-0.a
  /usr/lib/libgtk4-layer-shell-0.a
```