### PR TITLE
Fix broken heading links 

### DIFF
--- a/src/lib/docs/remark-heading-ids.mjs
+++ b/src/lib/docs/remark-heading-ids.mjs
@@ -3,10 +3,10 @@ import { visit } from "unist-util-visit";
 
 // remarkHeadingIds applies stable IDs and de-duplication indices to heading nodes.
 export default function remarkHeadingIds() {
-  // encounteredIDs tracks duplicate IDs so each heading receives a unique anchor.
-  const encounteredIDs = new Map();
-
   return (node) => {
+    // encounteredIDs tracks duplicate IDs so each heading receives a unique anchor.
+    const encounteredIDs = new Map();
+
     visit(node, "heading", (headingNode) => {
       if (!Array.isArray(headingNode.children) || headingNode.children.length === 0) {
         return;


### PR DESCRIPTION
## Problem

On https://ghostty.org/docs/features/ssh, the in-page `[shell integration](#shell-integration)` link is broken. It points to `#shell-integration`, but the heading on that page actually renders with `id="shell-integration-2"`.

## Root cause

In `src/lib/docs/remark-heading-ids.mjs`, the `encounteredIDs` Map used to de-duplicate heading IDs is created in the **plugin factory** scope:

```js
export default function remarkHeadingIds() {
  const encounteredIDs = new Map(); // shared across ALL docs
  return (node) => { ... };
}
```

Next.js instantiates the remark plugin once (see `next.config.mjs`) and reuses it for every MDX file, so the counter persists across documents. Multiple docs contain a "Shell Integration" heading (`docs/features/ssh.mdx`, `docs/install/release-notes/1-3-0.mdx`, `docs/install/release-notes/1-3-1.mdx`), so they get slugs like `shell-integration-2`, `shell-integration-3` etc. 

## Fix

Move the `encounteredIDs` Map inside the returned per-document transformer so the counter resets for each file. 

## Validation

Verified with a real `npm run build` and inspection of the generated static HTML:

- `docs/features/ssh.html`: heading id goes from `shell-integration-2` to `shell-integration` (i.e. previously broken link now works)
- `docs/install/build.html` (two `### Dependencies` headings): still correctly produces `dependencies` and `dependencies-2`