### PR TITLE
Update Debian mirror domain to deb.griffo.io

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -277,7 +277,7 @@ safer option.
 
 ### Debian
 
-Ghostty is available in [this community-maintained repository](https://debian.griffo.io/).
+Ghostty is available in [this community-maintained repository](https://deb.griffo.io/).
 
 Build, packaging and instructions for each version are available in the README of the [repository](https://github.com/dariogriffo/ghostty-debian).
 


### PR DESCRIPTION
Follow-up to #380.

The community Debian repository has moved from `debian.griffo.io` to `deb.griffo.io` to comply with the [Debian trademark policy](https://www.debian.org/trademark) (Debian trademarks may not be used in domain names). Same repository, packages, and signing key — only the domain changed.

The old domain serves permanent redirects, so existing links keep working, but the docs should point at the canonical URL.