### PR TITLE
Restore Debian install section, pointing at the always-free mirror

### DIFF
--- a/docs/install/binary.mdx
+++ b/docs/install/binary.mdx
@@ -275,6 +275,14 @@ safer option.
 
 </Warning>
 
+### Debian
+
+Ghostty is available in [this community-maintained repository](https://deb-free.griffo.io/) —
+free forever, with no account or authentication required.
+
+Build, packaging and instructions for each version are available in the README of the
+[repository](https://github.com/dariogriffo/ghostty-debian).
+
 ### Fedora
 
 Ghostty is available in [Fedora COPR](https://copr.fedorainfracloud.org/coprs/scottames/ghostty/).


### PR DESCRIPTION
Follow-up to the discussion in #274, per @mitchellh's approval there.

**Full disclosure of the model, as promised:** I run two apt repositories. The one linked here, [deb-free.griffo.io](https://deb-free.griffo.io/), is **free forever** — no account, no authentication, a commitment written into its terms. It serves each package's newest release that is at least two months old, with security and patch releases of the served series published immediately; given Ghostty's release cadence, it carries the current stable (1.3.1 today) essentially year-round. A separate commercial repository (deb.griffo.io, paid subscriptions from October 2026) serves every release within hours of upstream — it is deliberately **not** referenced in this listing or in the free mirror's install instructions.

Packages are per-release Debian builds (bookworm / trixie / forky / sid), built in the public [ghostty-debian](https://github.com/dariogriffo/ghostty-debian) packaging repo and GPG-signed with the same key in use since January.