### PR TITLE
docs: clarify `window-padding` settings docs

### DIFF
--- a/docs/config/reference.mdx
+++ b/docs/config/reference.mdx
@@ -1943,7 +1943,7 @@ This configuration can be repeated to specify multiple remaps.
 
 ## `window-padding-x`
 
-Horizontal window padding. This applies padding between the terminal cells
+Horizontal window padding. This applies padding between the first terminal cell
 and the left and right window borders. The value is in points, meaning that
 it will be scaled appropriately for screen DPI.
 
@@ -1963,7 +1963,7 @@ paddings to the same value, you can use a single value. For example,
 
 ## `window-padding-y`
 
-Vertical window padding. This applies padding between the terminal cells and
+Vertical window padding. This applies padding between the first terminal cell
 the top and bottom window borders. The value is in points, meaning that it
 will be scaled appropriately for screen DPI.
 


### PR DESCRIPTION
The sentense "between terminal cells" is slightly confusing because it reads like the padding also applies between the cells themselves.

Let's change to "between the first cell and ..." to be more accurate.