### PR TITLE
Add gtk-enable-primary-paste note to copy-on-select doc

### DIFF
--- a/docs/config/reference.mdx
+++ b/docs/config/reference.mdx
@@ -2461,10 +2461,15 @@ the system clipboard.
 The value `clipboard` will always copy text to the selection clipboard
 as well as the system clipboard.
 
-Middle-click paste will always use the selection clipboard. Middle-click
-paste is always enabled even if this is `false`.
-
 The default value is true on Linux and macOS.
+
+Middle-click paste always uses the selection clipboard, even if `copy-on-select`
+is false. On GTK, middle-click paste also requires `gtk-enable-primary-paste`
+be set to true. Check its effective value with:
+
+```
+gsettings get org.gnome.desktop.interface gtk-enable-primary-paste
+```
 
 ## `right-click-action`
 


### PR DESCRIPTION
ghostty 1.3.0 added support for this setting. I started using ghostty and was confused by this - especially when I found these docs which said it was always enabled.

It feels weird to suggest the `gsettings` CLI in docs like this, but on the flip side, it could save users like me a bit of time.

Ref: https://github.com/ghostty-org/ghostty/issues/10328